### PR TITLE
feat(search): add global setting search with keyboard navigation and fix fcitx5 IME handling

### DIFF
--- a/docs/DEVELOPER_README.md
+++ b/docs/DEVELOPER_README.md
@@ -4,7 +4,7 @@
 
 ## 技术栈
 
-Twilight Echo 是 Electron + Vue 3 + TypeScript 应用，使用 electron-vite 构建，electron-builder 打包。当前包信息为 `TwilightEcho@1.0.2`，许可证为 Apache-2.0。
+Twilight Echo 是 Electron + Vue 3 + TypeScript 应用，使用 electron-vite 构建，electron-builder 打包。当前包信息为 `TwilightEcho@1.0.3`，许可证为 Apache-2.0。
 
 核心依赖：
 
@@ -162,6 +162,37 @@ pnpm install --frozen-lockfile
 ```bash
 pnpm run dev
 ```
+
+### Linux 输入法（fcitx5/ibus）说明
+
+KDE Plasma Wayland 会话下，KWin 只有在 `kwinrc` 的 `[Wayland]` 组配置了
+`InputMethod`（KDE 系统设置 → 虚拟键盘）时，才会向 Wayland 客户端暴露
+`zwp_input_method` 协议 —— 这是 Wayland 原生 text-input 通道的前提。未配置时，
+Chromium/Electron 在 Wayland 下无法通过 text-input 使用 fcitx5/ibus。
+
+处理方式（见 `src/main/imeBackend.ts` 与 `src/main/app/lifecycle.ts`）：
+
+- 检测到「Linux + Wayland + KWin/Plasma + 未配置输入法」时，应用以真实启动参数
+  `--ozone-platform=x11` 运行（X11/XWayland 后端），fcitx5 通过
+  `GTK_IM_MODULE`/XIM 链路工作，与 VS Code 等 Electron 应用一致。
+- 为什么必须用真实参数：Chromium 的 ozone 平台在 Electron 二进制启动阶段确定，
+  早于任何主进程 JS。环境变量（`OZONE_PLATFORM` 等）对 Electron 无效；
+  `app.commandLine.appendSwitch()` 只影响子进程（renderer/GPU），无法改变
+  browser 进程自身。
+- 开发/预览模式（`pnpm run dev` / `pnpm run start`）由
+  `scripts/run-electron-vite.cjs` 在启动时透传参数（electron-vite 的 `--` 透传
+  机制）；打包后的生产模式由 `src/main/index.ts` 的 `relaunchWithX11BackendIfNeeded()`
+  自重启并携带参数。
+- KWin 已配置输入法时，遵循 fcitx-im 官方建议使用 text-input-v1（KWin 对
+  text-input-v3 存在协议理解差异）；GNOME/Sway 等仅支持 v3 的 compositor 保持 v3。
+
+渲染层 IME 注意事项（`src/renderer/src/components/AnimatedInput.vue`）：
+
+- 自定义输入框不得在 IME composition 期间丢弃 `input` 事件：X11/XIM 路径下
+  commit 文本的 `input` 事件可能与 `compositionend` 时序不一致，只依赖
+  `compositionend` + `setTimeout(0)` 兜底会丢失已提交的中文。
+- 不要对需要中文输入的输入框使用 `type="search"`（Chromium 对 search 框有独立
+  IME/清除按钮处理，提交时序与 `type="text"` 不同），统一用 `type="text"`。
 
 类型检查与构建：
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -89,7 +89,7 @@ linux:
   maintainer: mrcwoods
   category: Audio
   icon: build/icon.png
-  executableName: TwilightEcho
+  executableName: music
   synopsis: Modern desktop music player
   description: >
     Twilight Echo is a modern desktop music player for local collections,

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,7 +9,11 @@ electronLanguages:
   - zh-TW
   - en-US
 icon: build/icon.png
-afterPack: scripts/after-pack-windows.cjs
+# Single after-pack hook that dispatches to platform-specific scripts
+# (scripts/after-pack.cjs -> after-pack-windows.cjs / after-pack-linux.cjs).
+# Keeps Windows (rcedit icon/version injection) and Linux (native libs)
+# packaging fully isolated.
+afterPack: scripts/after-pack.cjs
 files:
   - out/**
   - package.json
@@ -74,11 +78,22 @@ dmg:
   artifactName: ${name}-${version}.${ext}
 linux:
   target:
-    - AppImage
-    - snap
-    - deb
-  maintainer: electronjs.org
-  category: Utility
+    - target: AppImage
+      arch: [x64]
+    - target: deb
+      arch: [x64]
+    - target: rpm
+      arch: [x64]
+    - target: tar.gz
+      arch: [x64]
+  maintainer: mrcwoods
+  category: Audio
+  icon: build/icon.png
+  executableName: TwilightEcho
+  synopsis: Modern desktop music player
+  description: >
+    Twilight Echo is a modern desktop music player for local collections,
+    streaming exploration, and HiFi playback.
 appImage:
   artifactName: ${name}-${version}.${ext}
 npmRebuild: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TwilightEcho",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Twilight Echo music player",
   "license": "Apache-2.0",
   "main": "./out/main/index.js",
@@ -69,8 +69,8 @@
     "smoke:asio-native-dsd": "node scripts/asio-native-dsd-smoke.cjs",
     "smoke:audio-evidence": "node scripts/audio-smoke-evidence.cjs",
     "smoke:audio-performance": "node scripts/audio-performance-soak.cjs",
-    "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "start": "node scripts/run-electron-vite.cjs preview",
+    "dev": "node scripts/run-electron-vite.cjs dev",
     "build": "pnpm run typecheck && electron-vite build && node scripts/strip-renderer-font-assets.cjs out/renderer && pnpm run verify:renderer-budgets",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm run build && node scripts/build-app-package.cjs --dir",

--- a/scripts/after-pack-linux.cjs
+++ b/scripts/after-pack-linux.cjs
@@ -1,4 +1,4 @@
-const { existsSync, copyFileSync, mkdirSync } = require('node:fs')
+const { copyFileSync, mkdirSync } = require('node:fs')
 const { join } = require('node:path')
 
 exports.default = async function afterPack(context) {

--- a/scripts/after-pack-linux.cjs
+++ b/scripts/after-pack-linux.cjs
@@ -1,0 +1,26 @@
+const { existsSync, copyFileSync, mkdirSync } = require('node:fs')
+const { join } = require('node:path')
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'linux') return
+
+  // Ensure native audio engine libraries are in the right place
+  const resourcesDir = join(context.appOutDir, 'resources', 'audio-engine')
+  const buildDir = join(context.packager.projectDir, 'audio-engine', 'build', 'default')
+
+  const runtimeFiles = ['libtwilight-audio-engine.so', 'twilight_audio_node.node']
+  mkdirSync(resourcesDir, { recursive: true })
+
+  for (const file of runtimeFiles) {
+    const source = join(buildDir, file)
+    const target = join(resourcesDir, file)
+    try {
+      copyFileSync(source, target)
+      console.log(`  Staged: ${file}`)
+    } catch (err) {
+      console.warn(`  Could not stage ${file}: ${err.message}`)
+    }
+  }
+
+  console.log('[after-pack-linux] Linux audio engine resources staged.')
+}

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -1,0 +1,17 @@
+// Unified after-pack dispatcher.
+//
+// electron-builder's `afterPack` accepts a single script path (not an array),
+// so this dispatcher routes to the platform-specific hooks below. Each hook
+// is responsible for its own platform guard.
+const { join } = require('node:path')
+
+exports.default = async function afterPack(context) {
+  const { electronPlatformName } = context
+  if (electronPlatformName === 'win32') {
+    return require(join(__dirname, 'after-pack-windows.cjs')).default(context)
+  }
+  if (electronPlatformName === 'linux') {
+    return require(join(__dirname, 'after-pack-linux.cjs')).default(context)
+  }
+  // mac / darwin: no custom after-pack steps yet.
+}

--- a/scripts/run-electron-vite.cjs
+++ b/scripts/run-electron-vite.cjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * electron-vite dev / preview 启动包装。
+ *
+ * 在 KDE Plasma Wayland 且 KWin 未配置输入法（kwinrc [Wayland] 组无
+ * InputMethod）时，向 electron 透传 --ozone-platform=x11，强制应用以
+ * X11（XWayland）后端运行 —— fcitx5/ibus 才能通过 GTK_IM_MODULE / XIM
+ * 输入中文。原因：
+ *  - Electron 43 在 Wayland 会话默认使用 Wayland ozone；
+ *  - OZONE_PLATFORM 等环境变量对 Electron 无效；
+ *  - app.commandLine.appendSwitch() 无法改变 browser 进程的 ozone 平台；
+ *  - 只有真实命令行参数 --ozone-platform=x11 有效。
+ * electron-vite 会把 `--` 之后的参数原样传给 electron
+ * （ELECTRON_CLI_ARGS 机制），因此这里只需要在启动时追加即可。
+ *
+ * 用法：node scripts/run-electron-vite.cjs dev | preview
+ * 对应 package.json 中的 "dev" / "start" 脚本。
+ */
+'use strict'
+
+const { spawn } = require('node:child_process')
+const { homedir } = require('node:os')
+const { join } = require('node:path')
+const { readFileSync } = require('node:fs')
+
+const command = process.argv[2]
+if (command !== 'dev' && command !== 'preview') {
+  console.error('用法：node scripts/run-electron-vite.cjs <dev|preview>')
+  process.exit(2)
+}
+
+function kwinHasInputMethodConfigured() {
+  try {
+    const content = readFileSync(join(homedir(), '.config', 'kwinrc'), 'utf8')
+    const waylandSection = content.match(/^\[Wayland\]([\s\S]*?)(?=^\s*\[|$)/m)
+    if (!waylandSection) return false
+    return /^\s*InputMethod\s*=/m.test(waylandSection[1])
+  } catch {
+    return false
+  }
+}
+
+function shouldUseX11Backend() {
+  if (process.platform !== 'linux' || process.env.XDG_SESSION_TYPE !== 'wayland') {
+    return false
+  }
+  const desktop = (
+    process.env.XDG_CURRENT_DESKTOP ||
+    process.env.XDG_SESSION_DESKTOP ||
+    ''
+  ).toLowerCase()
+  const isKWin = desktop.includes('kde') || desktop.includes('plasma')
+  return isKWin && !kwinHasInputMethodConfigured()
+}
+
+// 用户通过 `pnpm run dev -- <electron参数>` 透传的额外 electron 参数
+const electronArgs = process.argv.slice(3)
+if (shouldUseX11Backend()) {
+  electronArgs.unshift('--ozone-platform=x11')
+}
+// 统一放在 `--` 之后，交给 electron-vite 原样传给 electron
+const args = [command, '--', ...electronArgs]
+
+const bin = process.platform === 'win32' ? 'electron-vite.cmd' : 'electron-vite'
+const child = spawn(bin, args, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32'
+})
+child.on('close', (code) => {
+  process.exit(code ?? 0)
+})

--- a/src/main/app/lifecycle.ts
+++ b/src/main/app/lifecycle.ts
@@ -6,6 +6,7 @@ import { fetch as undiciFetch } from 'undici'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { runtime } from '../core/runtime'
 import { ensureMusicCacheDirectories } from '../cache/ncmCache'
+import { kwinHasInputMethodConfigured } from '../imeBackend'
 import {
   getCoverCacheContentType,
   isCoverCacheFileName,
@@ -69,6 +70,33 @@ export function startApp(): void {
   // Streaming provider URLs are resolved asynchronously after user commands.
   // Desktop playback must not be blocked by Chromium's web-page autoplay policy.
   app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
+
+  // Linux Wayland 下的输入法（fcitx5/ibus）集成：
+  // - KWin 只有在系统设置里配置了「虚拟键盘/输入法」时才会暴露
+  //   zwp_input_method 协议（text-input 通道的前提）。未配置时，
+  //   Wayland 原生客户端的 text-input 完全不可用，导致 fcitx5 无法输入。
+  //   此时回退到 X11（XWayland）后端，让 fcitx5 通过 GTK_IM_MODULE /
+  //   XIM 的 dbus 前端工作（与 VS Code 等 Electron 应用一致）。
+  // - KWin 已配置输入法时，遵循 fcitx-im 官方建议使用 text-input-v1：
+  //   KWin 对 zwp_text_input_v3 的实现与 Chromium 存在协议理解差异。
+  // - GNOME/Sway 等仅支持 text-input-v3 的 compositor 保持 v3。
+  if (process.platform === 'linux' && process.env.XDG_SESSION_TYPE === 'wayland') {
+    const desktop = (
+      process.env.XDG_CURRENT_DESKTOP ||
+      process.env.XDG_SESSION_DESKTOP ||
+      ''
+    ).toLowerCase()
+    const isKWin = desktop.includes('kde') || desktop.includes('plasma')
+
+    if (isKWin && !kwinHasInputMethodConfigured()) {
+      app.commandLine.appendSwitch('ozone-platform', 'x11')
+    } else {
+      app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform')
+      app.commandLine.appendSwitch('ozone-platform-hint', 'auto')
+      app.commandLine.appendSwitch('enable-wayland-ime')
+      app.commandLine.appendSwitch('wayland-text-input-version', isKWin ? '1' : '3')
+    }
+  }
 
   // Linux 上透明窗口需要显式启用透明视觉，否则整窗不渲染（纯透明）
   if (process.platform === 'linux' && runtime.appSettings.windowTransparency === true) {

--- a/src/main/imeBackend.ts
+++ b/src/main/imeBackend.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
+import { readFileSync } from 'fs'
+
+/**
+ * Linux 输入法（fcitx5/ibus）后端选择。
+ *
+ * 背景：KWin（KDE Plasma）只有在 kwinrc 的 [Wayland] 组配置了
+ * InputMethod（KDE 系统设置 → 虚拟键盘）时，才会向 Wayland 客户端暴露
+ * zwp_input_method 协议 —— 这是 text-input 通道的前提。未配置时，
+ * Chromium/Electron 在 Wayland 下无法通过 text-input 使用 fcitx5/ibus，
+ * 只能回退到 X11（XWayland）后端（fcitx5 通过 GTK_IM_MODULE / XIM 工作）。
+ *
+ * 关键限制：Chromium 的 ozone 平台在 Electron 二进制启动阶段就已确定，
+ * 早于任何主进程 JS 代码执行：
+ * - 环境变量（OZONE_PLATFORM 等）对 Electron 无效；
+ * - app.commandLine.appendSwitch() 只影响子进程（renderer/GPU），
+ *   无法改变 browser 进程自身；
+ * - 只有真实命令行参数 --ozone-platform=x11 才能让 browser 进程
+ *   走 X11（XWayland）后端。
+ * 因此需要 X11 回退时，只能「重启自身并携带该参数」。
+ */
+
+/** 强制 X11 后端的启动参数。 */
+export const OZONE_X11_SWITCH = '--ozone-platform=x11'
+
+/**
+ * KWin 是否在 kwinrc 中配置了输入法/虚拟键盘（决定 Wayland 下
+ * text-input 通道是否可用）。
+ */
+export function kwinHasInputMethodConfigured(): boolean {
+  try {
+    const kwinrcPath = join(homedir(), '.config', 'kwinrc')
+    const content = readFileSync(kwinrcPath, 'utf8')
+    const waylandSection = content.match(/^\[Wayland\]([\s\S]*?)(?=^\s*\[|$)/m)
+    if (!waylandSection) return false
+    return /^\s*InputMethod\s*=/m.test(waylandSection[1])
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 当前环境是否需要以 X11（XWayland）后端运行。
+ * 仅当：Linux + Wayland 会话 + KWin/Plasma + 未配置输入法时为 true。
+ */
+export function shouldUseX11Backend(): boolean {
+  if (process.platform !== 'linux' || process.env.XDG_SESSION_TYPE !== 'wayland') {
+    return false
+  }
+  const desktop = (
+    process.env.XDG_CURRENT_DESKTOP ||
+    process.env.XDG_SESSION_DESKTOP ||
+    ''
+  ).toLowerCase()
+  const isKWin = desktop.includes('kde') || desktop.includes('plasma')
+  return isKWin && !kwinHasInputMethodConfigured()
+}
+
+/**
+ * 生产环境（打包后）入口调用：检测到需要 X11 后端且当前进程未携带
+ * --ozone-platform=x11 时，以该参数重启自身，然后退出当前进程。
+ *
+ * 开发/预览模式（NODE_ENV_ELECTRON_VITE 已设置）不做自重启 ——
+ * electron-vite 管理 electron 进程生命周期（electron 退出时 electron-vite
+ * 也会退出，dev server 随之关闭），此时由 scripts/run-electron-vite.cjs
+ * 在启动时透传参数。
+ *
+ * @returns 是否已触发重启（调用方此时应停止继续初始化）。
+ */
+export function relaunchWithX11BackendIfNeeded(): boolean {
+  // electron-vite dev/preview 管理 electron 进程，交给启动脚本处理
+  if (process.env.NODE_ENV_ELECTRON_VITE) return false
+  if (!shouldUseX11Backend()) return false
+  // 当前已携带该参数（重启后的进程），无需再次重启
+  if (process.argv.includes(OZONE_X11_SWITCH)) return false
+
+  // 以相同参数（保留 argv[1] = app 入口）重启自身，追加 X11 参数。
+  // 打包后 argv[1] 是 app.asar 路径；stdio inherit 保持终端日志连续。
+  const args = process.argv.slice(1).concat([OZONE_X11_SWITCH])
+  const child = spawn(process.execPath, args, {
+    stdio: 'inherit',
+    env: process.env
+  })
+  child.on('error', (err) => {
+    console.error('[ime-backend] 无法以 X11 后端重启应用，继续当前模式：', err)
+  })
+  // 无论如何立即退出当前（Wayland 后端）进程。
+  process.exit(0)
+  return true
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,13 @@
+import { relaunchWithX11BackendIfNeeded } from './imeBackend'
+
+// 必须在加载应用生命周期之前执行：Chromium 的 ozone 平台在 Electron
+// 二进制启动阶段就已确定（早于任何 JS 代码），KWin 未配置输入法时
+// 只能以真实参数 --ozone-platform=x11 重启自身，让 browser 进程走
+// X11（XWayland）后端，fcitx5/ibus 才能输入中文。
+// 开发/预览模式由 scripts/run-electron-vite.cjs 在启动时透传参数，
+// 此处不会触发自重启。
+relaunchWithX11BackendIfNeeded()
+
 import { startApp } from './app/lifecycle'
 
 startApp()

--- a/src/renderer/src/components/AnimatedInput.vue
+++ b/src/renderer/src/components/AnimatedInput.vue
@@ -65,17 +65,39 @@ function syncScroll(): void {
   })
 }
 
-// Mirror native v-model semantics: hold updates while an IME composition is in
-// flight so the committed text animates in as one burst, not per pinyin key.
+// Mirror native v-model semantics. The native <input> always owns the true
+// value, so every input event carries the current text — including IME
+// composition updates and the final commit. We must NOT drop input events
+// while composing: on X11/XIM the input event for the committed text may
+// arrive after compositionend (or compositionend may not fire reliably),
+// so emitting from input keeps the committed text flowing into modelValue.
+// During composition the raw text is shown via the .is-composing class.
 function onInput(event: Event): void {
-  if (composing.value) return
   emit('update:modelValue', (event.target as HTMLInputElement).value)
   syncScroll()
 }
 
-function onCompositionEnd(event: Event): void {
+function commitCompositionValue(): void {
+  const value = inputEl.value?.value ?? ''
+  emit('update:modelValue', value)
+  syncScroll()
+}
+
+function onCompositionUpdate(): void {
+  composing.value = true
+  syncScroll()
+}
+
+function onCompositionEnd(): void {
   composing.value = false
-  onInput(event)
+  // Fallback: on some platforms the committed text is only visible after a
+  // tick (X11/XIM), or the final input event is dropped. Reading the value
+  // asynchronously guarantees the committed grapheme reaches modelValue.
+  window.setTimeout(commitCompositionValue, 0)
+}
+
+function onCompositionCancel(): void {
+  composing.value = false
 }
 </script>
 
@@ -94,7 +116,9 @@ function onCompositionEnd(event: Event): void {
       @input="onInput"
       @scroll="syncScroll"
       @compositionstart="composing = true"
+      @compositionupdate="onCompositionUpdate"
       @compositionend="onCompositionEnd"
+      @compositioncancel="onCompositionCancel"
     />
     <span class="animated-input-mirror" aria-hidden="true">
       <span class="animated-input-track" :style="{ transform: `translate3d(${-scrollX}px, 0, 0)` }">

--- a/src/renderer/src/components/SettingsPage.vue
+++ b/src/renderer/src/components/SettingsPage.vue
@@ -10,6 +10,7 @@ import AnimatedInput from './AnimatedInput.vue'
 import {
   type SectionKey,
   type BooleanSettingKey,
+  type SettingsSearchEntry,
   sections,
   colorModeOptions,
   playbackResumeOptions,
@@ -416,18 +417,36 @@ const selectedPluginThemeKey = computed(() => {
 const pluginSettingsPanels = computed(() =>
   uiContributions.value.filter((contribution) => contribution.kind === 'settingsPanel')
 )
-const filteredSettingsSections = computed(() => {
+const activeSearchIndex = ref(-1)
+const filteredSearchResults = computed(() => {
   const query = settingsSearchQuery.value.trim().toLowerCase()
   if (!query) return []
-  return SETTINGS_SEARCH_INDEX.filter((item) =>
-    `${item.title} ${item.terms}`.toLowerCase().includes(query)
-  )
+  const matches = SETTINGS_SEARCH_INDEX.map((entry) => {
+    const title = entry.title.toLowerCase()
+    const terms = entry.terms.toLowerCase()
+    let score = 0
+    if (title === query) score = 4
+    else if (title.startsWith(query)) score = 3
+    else if (title.includes(query)) score = 2
+    else if (terms.includes(query)) score = 1
+    return { entry, score }
+  })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map(({ entry }) => entry)
+  return matches
+})
+// 结果集变化时修正选中索引，避免越界
+watch(filteredSearchResults, (matches) => {
+  if (activeSearchIndex.value >= matches.length) {
+    activeSearchIndex.value = matches.length > 0 ? 0 : -1
+  }
 })
 const hasSettingsSearchResults = computed(
-  () => settingsSearchQuery.value.trim().length > 0 && filteredSettingsSections.value.length > 0
+  () => settingsSearchQuery.value.trim().length > 0 && filteredSearchResults.value.length > 0
 )
 const hasSettingsSearchNoResults = computed(
-  () => settingsSearchQuery.value.trim().length > 0 && filteredSettingsSections.value.length === 0
+  () => settingsSearchQuery.value.trim().length > 0 && filteredSearchResults.value.length === 0
 )
 const selectedAudioOutput = computed(() =>
   audioOutputOptions.value.find((option) => option.id === audioOutput.value)
@@ -1818,9 +1837,90 @@ function scrollToSection(section: SectionKey): void {
   document.getElementById(section)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
-function scrollToSearchResult(section: SectionKey): void {
+function scrollToSearchResult(entry: SettingsSearchEntry): void {
   settingsSearchQuery.value = ''
-  scrollToSection(section)
+  scrollToSection(entry.section)
+  // 定位到具体的设置项
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const sectionEl = document.getElementById(entry.section)
+      if (!sectionEl) return
+      const target = findSettingItem(sectionEl, entry)
+      target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      highlightSettingItem(target)
+    })
+  })
+}
+
+function findSettingItem(
+  sectionEl: HTMLElement,
+  entry: SettingsSearchEntry
+): HTMLElement | null {
+  const matchText = (entry.match ?? entry.title).trim().toLowerCase()
+  // 优先匹配 .setting-item（常规设置项）
+  const settingItems = sectionEl.querySelectorAll<HTMLElement>('.setting-item')
+  for (const item of settingItems) {
+    const copy = item.querySelector('.setting-copy')
+    const strong = copy?.querySelector('strong')
+    if (strong && strong.textContent?.trim().toLowerCase().includes(matchText)) {
+      return item
+    }
+  }
+  // 回退：匹配 h3 区块标题（如 about 分区）
+  const headings = sectionEl.querySelectorAll<HTMLElement>('h3')
+  for (const heading of headings) {
+    if (heading.textContent?.trim().toLowerCase().includes(matchText)) {
+      return heading
+    }
+  }
+  // 再回退：匹配任意 strong / span / button 文本（about 的更新卡、赞助卡等）
+  const fallbacks = sectionEl.querySelectorAll<HTMLElement>('strong, span, button')
+  for (const el of fallbacks) {
+    if (el.textContent?.trim().toLowerCase().includes(matchText)) {
+      return el
+    }
+  }
+  return null
+}
+
+let searchHighlightTimer: number | null = null
+
+function highlightSettingItem(item: HTMLElement | null): void {
+  if (searchHighlightTimer !== null) {
+    window.clearTimeout(searchHighlightTimer)
+    searchHighlightTimer = null
+  }
+  document.querySelectorAll('.setting-item.search-target-flash').forEach((el) => {
+    el.classList.remove('search-target-flash')
+  })
+  if (!item) return
+  item.classList.add('search-target-flash')
+  searchHighlightTimer = window.setTimeout(() => {
+    item.classList.remove('search-target-flash')
+    searchHighlightTimer = null
+  }, 2200)
+}
+
+function moveSearchSelection(delta: number): void {
+  const results = filteredSearchResults.value
+  if (results.length === 0) return
+  const next = activeSearchIndex.value + delta
+  activeSearchIndex.value = ((next % results.length) + results.length) % results.length
+}
+
+function handleSettingsSearchEnter(): void {
+  const results = filteredSearchResults.value
+  if (results.length === 0) return
+  const target =
+    activeSearchIndex.value >= 0 && activeSearchIndex.value < results.length
+      ? results[activeSearchIndex.value]
+      : results[0]
+  scrollToSearchResult(target)
+}
+
+function clearSettingsSearch(): void {
+  settingsSearchQuery.value = ''
+  activeSearchIndex.value = -1
 }
 
 async function refreshShortcutStatuses(): Promise<void> {
@@ -1908,34 +2008,76 @@ onBeforeUnmount(() => {
     />
     <div class="settings-preview-layout">
       <nav class="settings-preview-nav" aria-label="设置分区">
-        <button
-          v-for="section in sections"
-          :key="section.key"
-          type="button"
-          class="preview-nav-item"
-          :class="{ active: activeSection === section.key }"
-          @click="scrollToSection(section.key)"
-        >
-          <i :class="section.icon"></i>
-          <span>{{ section.label }}</span>
-        </button>
-      </nav>
+          <div class="settings-nav-search-wrap">
+            <div class="settings-search-box settings-nav-search">
+              <i class="pi pi-search"></i>
+              <AnimatedInput
+                v-model="settingsSearchQuery"
+                type="text"
+                class="settings-search-input"
+                placeholder="搜索设置"
+                aria-label="搜索设置"
+                @focus="activeSearchIndex = filteredSearchResults.length > 0 ? 0 : -1"
+                @keydown.down.prevent="moveSearchSelection(1)"
+                @keydown.up.prevent="moveSearchSelection(-1)"
+                @keydown.enter.prevent="handleSettingsSearchEnter"
+                @keydown.esc.prevent="clearSettingsSearch"
+              />
+              <button
+                v-if="settingsSearchQuery"
+                type="button"
+                class="settings-search-clear"
+                @click="clearSettingsSearch"
+                aria-label="清除搜索"
+              >
+                <i class="pi pi-times"></i>
+              </button>
+            </div>
+            <div
+              v-if="hasSettingsSearchResults"
+              class="settings-nav-results"
+              role="listbox"
+              aria-label="搜索结果"
+            >
+              <button
+                v-for="(result, index) in filteredSearchResults"
+                :key="`${result.section}:${result.title}`"
+                type="button"
+                role="option"
+                :aria-selected="activeSearchIndex === index"
+                :class="{ active: activeSearchIndex === index }"
+                @mouseenter="activeSearchIndex = index"
+                @click="scrollToSearchResult(result)"
+              >
+                <i :class="sections.find((section) => section.key === result.section)?.icon"></i>
+                <span class="settings-nav-result-title">{{ result.title }}</span>
+                <small>{{
+                  sections.find((section) => section.key === result.section)?.label
+                }}</small>
+              </button>
+            </div>
+            <div v-else-if="hasSettingsSearchNoResults" class="settings-nav-empty">
+              没有找到匹配的设置
+            </div>
+          </div>
+          <button
+            v-for="section in sections"
+            :key="section.key"
+            type="button"
+            class="preview-nav-item"
+            :class="{ active: activeSection === section.key }"
+            @click="scrollToSection(section.key)"
+          >
+            <i :class="section.icon"></i>
+            <span>{{ section.label }}</span>
+          </button>
+        </nav>
 
       <div class="settings-preview-stack">
         <header class="settings-page-header">
           <h1 class="settings-page-title">设置</h1>
         </header>
         <section class="settings-command-bar glass-card">
-          <div class="settings-search-box">
-            <i class="pi pi-search"></i>
-            <AnimatedInput
-              v-model="settingsSearchQuery"
-              type="search"
-              class="settings-search-input"
-              placeholder="搜索设置"
-              aria-label="搜索设置"
-            />
-          </div>
           <div class="settings-command-actions">
             <button type="button" class="soft-button" @click="exportSettingsBackup">
               <i class="pi pi-download"></i>
@@ -1945,20 +2087,6 @@ onBeforeUnmount(() => {
               <i class="pi pi-upload"></i>
               导入设置
             </button>
-          </div>
-          <div v-if="hasSettingsSearchResults" class="settings-search-results">
-            <button
-              v-for="result in filteredSettingsSections"
-              :key="result.section"
-              type="button"
-              @click="scrollToSearchResult(result.section)"
-            >
-              <i :class="sections.find((section) => section.key === result.section)?.icon"></i>
-              {{ result.title }}
-            </button>
-          </div>
-          <div v-else-if="hasSettingsSearchNoResults" class="settings-search-empty">
-            没有找到匹配的设置
           </div>
           <div v-if="settingsNotice" class="settings-inline-notice">{{ settingsNotice }}</div>
           <div v-if="settingsError" class="settings-inline-error">{{ settingsError }}</div>
@@ -5525,13 +5653,35 @@ html[data-theme='dark'] .settings-preview-page .inherit-toggle,
 html[data-theme='dark'] .settings-preview-page .pill-action.ghost,
 html[data-theme='dark'] .settings-preview-page .dashed-button,
 html[data-theme='dark'] .settings-preview-page .settings-search-box,
-html[data-theme='dark'] .settings-preview-page .settings-search-empty,
+html[data-theme='dark'] .settings-preview-page .settings-nav-search,
 html[data-theme='dark'] .settings-preview-page .shortcut-status-row,
 html[data-theme='dark'] .settings-preview-page .read-only-pill {
   border-color: var(--te-card-border);
   background: var(--te-card-bg);
   color: rgba(226, 232, 240, 0.9);
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+}
+
+html[data-theme='dark'] .settings-preview-page .settings-nav-results,
+html[data-theme='dark'] .settings-preview-page .settings-nav-empty {
+  border-color: var(--te-card-border);
+  background: var(--te-card-bg);
+  color: rgba(226, 232, 240, 0.9);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.42);
+}
+
+html[data-theme='dark'] .settings-preview-page .settings-nav-results button {
+  color: rgba(226, 232, 240, 0.88);
+}
+
+html[data-theme='dark'] .settings-preview-page .settings-nav-results button:hover,
+html[data-theme='dark'] .settings-preview-page .settings-nav-results button.active {
+  background: rgba(var(--te-primary-rgb), 0.16);
+  color: var(--te-primary-300);
+}
+
+html[data-theme='dark'] .settings-preview-page .settings-nav-results button small {
+  color: rgba(148, 163, 184, 0.72);
 }
 
 html[data-theme='dark'] .settings-preview-page .accordion-head,
@@ -5733,7 +5883,7 @@ html[data-theme='dark'] .settings-preview-page .inherit-toggle.active {
 html[data-theme='dark'] .settings-preview-page .dashed-button:hover,
 html[data-theme='dark'] .settings-preview-page .brand-soft-button:hover,
 html[data-theme='dark'] .settings-preview-page .preset-btn:hover,
-html[data-theme='dark'] .settings-preview-page .settings-search-results button {
+html[data-theme='dark'] .settings-preview-page .settings-nav-results button.active {
   border-color: rgba(var(--te-primary-rgb), 0.34);
   background: rgba(var(--te-primary-rgb), 0.14);
   color: var(--te-primary-300);

--- a/src/renderer/src/components/settings-page/SettingsPage.css
+++ b/src/renderer/src/components/settings-page/SettingsPage.css
@@ -213,6 +213,151 @@
   }
 }
 
+/* ── 侧边栏搜索 ─────────────────────────────────────── */
+.settings-nav-search-wrap {
+  position: relative;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.settings-search-box.settings-nav-search {
+  min-height: 40px;
+  padding: 0 12px;
+  gap: 8px;
+}
+
+.settings-nav-search .settings-search-clear {
+  width: 26px;
+  height: 26px;
+}
+
+.settings-nav-results {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: calc(100% + 14px);
+  z-index: 220;
+  display: flex;
+  width: 300px;
+  max-height: min(56vh, 520px);
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--te-settings-control-border, rgba(15, 23, 42, 0.08));
+  border-radius: 14px;
+  background: var(--te-settings-nav-active, #ffffff);
+  box-shadow:
+    0 12px 32px rgba(15, 23, 42, 0.14),
+    0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+.settings-nav-results button {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--te-settings-text, #1a1a1a);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.14s ease,
+    color 0.14s ease;
+}
+
+.settings-nav-results button > i {
+  color: var(--brand-500);
+  font-size: 13px;
+  opacity: 0.9;
+}
+
+.settings-nav-results button small {
+  color: var(--te-settings-text-muted, #8a8f98);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.settings-nav-results button:hover,
+.settings-nav-results button.active {
+  background: rgba(var(--te-primary-rgb), 0.1);
+  color: var(--brand-600);
+}
+
+.settings-nav-results button.active {
+  box-shadow: inset 2px 0 0 var(--brand-500);
+}
+
+.settings-nav-result-title {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-nav-empty {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: calc(100% + 14px);
+  z-index: 220;
+  padding: 10px 14px;
+  border: 1px dashed rgba(156, 163, 175, 0.55);
+  border-radius: 12px;
+  background: var(--te-settings-nav-active, #ffffff);
+  color: var(--te-settings-text-muted, #8a8f98);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* 搜索结果定位到设置项后的高亮闪烁 */
+.settings-preview-page .setting-item.search-target-flash {
+  position: relative;
+  animation: te-search-flash 2.2s ease both;
+  border-radius: 12px;
+}
+
+.settings-preview-page .setting-item.search-target-flash::after {
+  position: absolute;
+  inset: -3px -6px;
+  border: 2px solid rgba(var(--te-primary-rgb), 0.55);
+  border-radius: 14px;
+  content: '';
+  pointer-events: none;
+}
+
+@keyframes te-search-flash {
+  0%,
+  100% {
+    box-shadow: none;
+  }
+  12%,
+  38% {
+    box-shadow:
+      0 0 0 4px rgba(var(--te-primary-rgb), 0.16),
+      0 8px 24px rgba(var(--te-primary-rgb), 0.22);
+  }
+  52%,
+  100% {
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 1180px) {
+  .settings-nav-results,
+  .settings-nav-empty {
+    left: 0;
+    width: 260px;
+  }
+}
+
 .settings-preview-stack {
   display: flex;
   width: min(100%, 896px);
@@ -269,6 +414,23 @@
   font-size: 14px;
 }
 
+.settings-search-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--te-settings-text-muted, #8a8f98);
+  cursor: pointer;
+}
+
+.settings-search-clear:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
 .settings-search-box input,
 .settings-search-box .settings-search-input {
   min-width: 0;
@@ -302,39 +464,12 @@
   gap: 10px;
 }
 
-.settings-search-results {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.settings-search-results button {
-  display: inline-flex;
-  min-height: 32px;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 999px;
-  background: rgba(var(--te-primary-rgb), 0.08);
-  color: var(--brand-600);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.settings-search-empty,
 .settings-inline-notice,
 .settings-inline-error {
   padding: 9px 12px;
   border-radius: 8px;
   font-size: 12px;
   font-weight: 650;
-}
-
-.settings-search-empty {
-  border: 1px dashed rgba(156, 163, 175, 0.55);
-  color: var(--te-settings-text-muted);
 }
 
 .settings-inline-notice {
@@ -3630,6 +3765,11 @@ html[data-density='compact'] .settings-search-box {
   padding-inline: 14px;
 }
 
+html[data-density='compact'] .settings-preview-page .settings-nav-search {
+  min-height: 40px;
+  padding-inline: 12px;
+}
+
 html[data-density='compact'] .preview-section {
   padding: 20px;
 }
@@ -3664,6 +3804,11 @@ html[data-density='comfortable'] .settings-command-bar {
 html[data-density='comfortable'] .settings-search-box {
   min-height: 52px;
   padding-inline: 22px;
+}
+
+html[data-density='comfortable'] .settings-preview-page .settings-nav-search {
+  min-height: 40px;
+  padding-inline: 12px;
 }
 
 html[data-density='comfortable'] .preview-section {

--- a/src/renderer/src/components/settings-page/types.ts
+++ b/src/renderer/src/components/settings-page/types.ts
@@ -204,44 +204,168 @@ export const streamingAudioCachePolicyOptions: {
 
 export { GITHUB_URL, HOMEPAGE_URL, RELEASES_URL } from '../../../../shared/projectUrls.ts'
 
-export const SETTINGS_SEARCH_INDEX: Array<{
+export interface SettingsSearchEntry {
+  /** 所属设置分区 */
   section: SectionKey
+  /** 结果展示标题（设置项名称） */
   title: string
+  /** 用于在 DOM 中定位设置项文本；默认取 title */
+  match?: string
+  /** 搜索关键词（别名 / 英文 / 相关词，空格分隔） */
   terms: string
-}> = [
-  {
-    section: 'general',
-    title: '媒体库与启动',
-    terms:
-      '常规 扫描 文件夹 监控 流派 分隔符 genre separator 网易云 SMTC Discord 启动 托盘 代理 插件设置 备份 恢复 远程 遥控 PIN DLNA 投送 局域网 操作习惯 单击播放 双击播放 右键菜单'
-  },
-  {
-    section: 'playback',
-    title: '播放与输出',
-    terms: '播放 输出 设备 独占 音量 削波 无缝 网易云 音质 无损 Hi-Res DSD SACD buffer routing'
-  },
-  {
-    section: 'dsp',
-    title: 'DSP 处理器',
-    terms:
-      'DSP EQ ReplayGain Crossfeed Convolver FFT High-Res DSD SACD VST3 插件 宿主 搜索目录 扫描'
-  },
-  { section: 'cache', title: '缓存策略', terms: '缓存 目录 封面 歌词 元数据 流媒体 BPM 分析 清理' },
-  { section: 'performance', title: '性能', terms: '性能 硬件加速 GPU 重启' },
-  {
-    section: 'appearance',
-    title: '外观与主题',
-    terms:
-      '外观 主题 插件主题 强调色 背景 字体 密度 动效 减少动画 歌词 卡片 迷你播放器 自定义 圆角 缩放 布局'
-  },
-  {
-    section: 'desktopLyrics',
-    title: '桌面歌词',
-    terms: '桌面歌词 字体 颜色 阴影 对齐 窗口 置顶 鼠标穿透 翻译 行偏移 错落 双语 原文'
-  },
-  { section: 'shortcuts', title: '快捷键', terms: '快捷键 全局 播放 暂停 上一首 下一首 注册 冲突' },
-  { section: 'about', title: '关于与更新', terms: '关于 版本 更新 GitHub Releases 开源 致谢' }
-]
+}
+
+const sectionTerms: Record<SectionKey, string> = {
+  general: '常规 设置 媒体库 启动 集成 网络',
+  playback: '播放 输出 引擎',
+  dsp: 'DSP 处理器 音效',
+  cache: '缓存 存储',
+  performance: '性能 优化',
+  appearance: '外观 主题 界面',
+  desktopLyrics: '桌面歌词 歌词',
+  shortcuts: '快捷键 快捷 热键',
+  about: '关于 版本 更新'
+}
+
+/** 设置项级细粒度搜索索引：每个设置项一条，保证任意设置项都能被搜到 */
+export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = ([
+  // ── 常规 ──────────────────────────────────────────────
+  { section: 'general', title: '扫描文件夹', terms: '媒体库 文件夹 目录 扫描 添加 本地 音乐 库' },
+  { section: 'general', title: '流派分隔符', terms: 'genre separator 标签 分隔 元数据' },
+  { section: 'general', title: '实时监控文件夹变动', terms: 'watch 监控 文件夹 自动 同步 媒体库 监听' },
+  { section: 'general', title: '在线歌词回退 (LRCLIB)', terms: '歌词 lyric 回退 provider LRCLIB 在线 搜索' },
+  { section: 'general', title: '媒体库监控状态', terms: 'watcher 状态 监控 监听 文件夹 降级' },
+  { section: 'general', title: '完整重扫', terms: 'rescan 重扫 扫描 元数据 封面 刷新 媒体库' },
+  { section: 'general', title: '启动时检查网易云登录', terms: '网易云 ncm 登录 检查 启动 账号' },
+  { section: 'general', title: '原生媒体控制 (SMTC)', terms: 'smtc 媒体控制 系统 媒体键 集成 windows' },
+  { section: 'general', title: 'Discord Rich Presence', terms: 'discord 状态 展示 集成 社交 游戏' },
+  { section: 'general', title: '局域网远程控制', terms: '远程 遥控 局域网 手机 控制 投送 DLNA' },
+  { section: 'general', title: '配对 PIN / 访问地址', terms: 'pin 配对 访问 地址 远程 安全' },
+  { section: 'general', title: '歌曲列表播放方式', terms: '单击 双击 播放 列表 操作 习惯 激活' },
+  { section: 'general', title: '启动后进入', terms: 'startup 主页 首页 启动 进入 本地 流媒体' },
+  { section: 'general', title: '开机自动启动', terms: '开机 启动 自启 登录 自动启动 launch at login' },
+  { section: 'general', title: '关闭主窗口时', terms: '关闭 主窗口 最小化 托盘 退出 行为 窗口' },
+  { section: 'general', title: '欢迎向导', terms: '向导 欢迎 onboarding 首次 引导' },
+  { section: 'general', title: '设置备份', terms: '备份 backup 导出 导入 恢复 设置' },
+  { section: 'general', title: '按分组恢复默认', terms: '恢复 默认 重置 reset 分组' },
+  { section: 'general', title: '插件设置', match: '插件设置', terms: '插件 plugin 面板 设置 扩展' },
+  { section: 'general', title: '代理模式', terms: '代理 proxy 模式 网络 系统 关闭' },
+  { section: 'general', title: '代理地址', terms: '代理 proxy 地址 host 服务器' },
+  { section: 'general', title: '代理端口', terms: '代理 proxy 端口 port' },
+  { section: 'general', title: '代理失败时允许直连', terms: '代理 proxy 直连 fallback 失败 回退' },
+
+  // ── 播放 ──────────────────────────────────────────────
+  { section: 'playback', title: '输出模式', terms: '输出 output 设备 音频 模式 声卡' },
+  { section: 'playback', title: 'DSD 直通路由', terms: 'dsd 直通 路由 sacd 采样 原始' },
+  { section: 'playback', title: 'Foobar2000 便携版兼容检测', terms: 'foobar2000 便携 兼容 检测 解码' },
+  { section: 'playback', title: '独占模式 (Exclusive)', terms: '独占 exclusive 输出 设备 绕过 混音' },
+  { section: 'playback', title: '音量与削波保护', terms: '音量 削波 clip 保护 响度 安全' },
+  { section: 'playback', title: '无缝播放 (Gapless Playback)', terms: '无缝 播放 gapless 间隙 连续 歌曲' },
+  { section: 'playback', title: '启动时恢复播放', terms: '恢复 播放 resume 上次 曲目 位置 启动' },
+  { section: 'playback', title: '睡眠定时器', terms: '睡眠 定时 sleep timer 停止 播放 计时' },
+  { section: 'playback', title: '网易云播放音质', terms: '网易云 ncm 音质 无损 hi-res lossless 标准' },
+  { section: 'playback', title: '高级引擎参数 (Advanced Engine)', terms: '引擎 engine buffer 缓冲 采样率 位深 高级' },
+  { section: 'playback', title: 'WASAPI 独占推送模式', terms: 'wasapi 独占 推送 模式 windows 输出' },
+
+  // ── DSP ───────────────────────────────────────────────
+  { section: 'dsp', title: '防破音保护 (Clip Guard)', terms: '防破音 clip guard 保护 削波 响度' },
+  { section: 'dsp', title: '音量标准化 (ReplayGain / Loudnorm)', terms: 'replaygain loudnorm 音量 标准化 响度 增益' },
+  { section: 'dsp', title: 'Preamp', terms: 'preamp 增益 前置 音量 标准化' },
+  { section: 'dsp', title: 'Fallback Gain', terms: 'fallback gain 增益 回退 音量' },
+  { section: 'dsp', title: 'ReplayGain Clip', terms: 'replaygain clip 削波 限制 增益' },
+  { section: 'dsp', title: 'Parametric EQ', terms: 'eq 均衡 均衡器 parametric 频率 增益' },
+  { section: 'dsp', title: '耳机交叉馈电 (Crossfeed)', terms: 'crossfeed 交叉 馈电 耳机 声场 空间' },
+  { section: 'dsp', title: 'Crossfeed Delay', terms: 'crossfeed delay 延迟 交叉 馈电' },
+  { section: 'dsp', title: 'Crossfeed Cutoff', terms: 'crossfeed cutoff 截止 频率 交叉 馈电' },
+  { section: 'dsp', title: '启用 VST3 宿主', terms: 'vst3 宿主 插件 启用 效果器 host' },
+  { section: 'dsp', title: 'VST3 搜索目录', match: '搜索目录', terms: 'vst3 搜索 目录 插件 扫描 路径' },
+  { section: 'dsp', title: '插件目录状态', terms: '插件 目录 状态 vst3 扫描 检测' },
+
+  // ── 缓存 ──────────────────────────────────────────────
+  { section: 'cache', title: '缓存目录', terms: '缓存 目录 cache 路径 存储 位置' },
+  { section: 'cache', title: '封面缓存', terms: '封面 cover 缓存 图片 清除' },
+  { section: 'cache', title: '歌词缓存', terms: '歌词 lyric 缓存 清除' },
+  { section: 'cache', title: '元数据缓存', terms: '元数据 metadata 缓存 清除' },
+  { section: 'cache', title: '流媒体音频缓存', terms: '流媒体 音频 缓存 streaming 缓存策略 网络' },
+  { section: 'cache', title: 'BPM 自动分析', terms: 'bpm 分析 自动 节奏 扫描' },
+  { section: 'cache', title: 'BPM 分析缓存', terms: 'bpm 分析 缓存 清除' },
+  { section: 'cache', title: 'Loudnorm / 响度分析缓存', terms: 'loudnorm 响度 分析 缓存 清除' },
+  { section: 'cache', title: '缓存占用', terms: '缓存 占用 大小 清理 清空 释放 空间' },
+
+  // ── 性能 ──────────────────────────────────────────────
+  { section: 'performance', title: '硬件加速', terms: '硬件 加速 gpu 渲染 显卡 性能' },
+  { section: 'performance', title: '窗口透明', terms: '窗口 透明 透明度 毛玻璃 玻璃 背景' },
+  { section: 'performance', title: '表面不透明度 (Surface Opacity)', terms: '表面 不透明度 opacity 透明度 窗口' },
+  { section: 'performance', title: '表面模糊度 (Surface Blur)', terms: '表面 模糊 blur 毛玻璃 窗口' },
+  { section: 'performance', title: '卡片不透明度 (Card Opacity)', terms: '卡片 不透明度 opacity 透明度' },
+  { section: 'performance', title: '卡片模糊度 (Card Blur)', terms: '卡片 模糊 blur 毛玻璃' },
+
+  // ── 外观 ──────────────────────────────────────────────
+  { section: 'appearance', title: '主题工作室 · Beta', terms: '主题 工作室 theme 编辑器 自定义 皮肤' },
+  { section: 'appearance', title: '主题模式', terms: '主题 模式 浅色 深色 系统 亮色 暗色' },
+  { section: 'appearance', title: '界面动效', terms: '动效 动画 减少动画 motion 特效 过渡' },
+  { section: 'appearance', title: '插件主题', terms: '插件 主题 plugin theme 扩展' },
+  { section: 'appearance', title: '浅色强调色', terms: '强调色 accent 浅色 颜色 主题' },
+  { section: 'appearance', title: '深色强调色', terms: '强调色 accent 深色 颜色 主题' },
+  { section: 'appearance', title: '自定义背景', terms: '背景 自定义 壁纸 图片 封面' },
+  { section: 'appearance', title: '统一背景', terms: '背景 统一 所有 页面 壁纸' },
+  { section: 'appearance', title: '页面背景覆盖', terms: '背景 页面 覆盖 独立 壁纸 图片' },
+  { section: 'appearance', title: '封面主题色', terms: '封面 主题色 cover 颜色 专辑' },
+  { section: 'appearance', title: '全局字体 (Typography)', terms: '字体 font typography 排版 全局' },
+  { section: 'appearance', title: '界面排版密度 (UI Density)', terms: '密度 ui density 排版 紧凑 宽松' },
+  { section: 'appearance', title: '歌词显示样式 (Lyrics Style)', terms: '歌词 lyric 样式 高亮 逐字 显示' },
+  { section: 'appearance', title: '逐字高亮', terms: '逐字 高亮 歌词 卡拉 ok 同步' },
+  { section: 'appearance', title: '卡片与背景自定义', terms: '卡片 背景 自定义 外观' },
+  { section: 'appearance', title: '启用自定义外观', terms: '外观 自定义 启用 卡片 开关' },
+  { section: 'appearance', title: '卡片模糊强度', terms: '卡片 模糊 强度 blur 毛玻璃' },
+  { section: 'appearance', title: '卡片模糊饱和度', terms: '卡片 模糊 饱和度 saturation blur' },
+  { section: 'appearance', title: '卡片背景颜色', terms: '卡片 背景 颜色 color' },
+  { section: 'appearance', title: '卡片边框', terms: '卡片 边框 border 描边' },
+  { section: 'appearance', title: '卡片圆角半径', terms: '卡片 圆角 radius 圆角 弧度' },
+  { section: 'appearance', title: '卡片阴影强度', terms: '卡片 阴影 强度 shadow 投影' },
+  { section: 'appearance', title: '卡片悬浮效果', terms: '卡片 悬浮 hover 效果 悬停' },
+  { section: 'appearance', title: '玻璃高光', terms: '玻璃 高光 glass highlight 光泽' },
+  { section: 'appearance', title: '背景模糊与暗化', terms: '背景 模糊 暗化 遮罩 blur darken' },
+  { section: 'appearance', title: '背景模糊', terms: '背景 模糊 blur 毛玻璃' },
+  { section: 'appearance', title: '背景亮度', terms: '背景 亮度 brightness 明暗' },
+  { section: 'appearance', title: '背景暗化遮罩', terms: '背景 暗化 遮罩 蒙版 overlay darken' },
+
+  // ── 桌面歌词 ──────────────────────────────────────────
+  { section: 'desktopLyrics', title: '启用桌面歌词', terms: '桌面歌词 启用 开关 显示 歌词' },
+  { section: 'desktopLyrics', title: '字体大小 (Font Size)', terms: '字体 大小 font size 字号 歌词' },
+  { section: 'desktopLyrics', title: '字体粗细 (Font Weight)', terms: '字体 粗细 font weight 加粗' },
+  { section: 'desktopLyrics', title: '行间距 (Line Spacing)', terms: '行距 间距 line spacing 歌词' },
+  { section: 'desktopLyrics', title: '最大显示行数 (Max Lines)', terms: '行数 max lines 显示 歌词' },
+  { section: 'desktopLyrics', title: '行水平偏移 (Line Offset)', terms: '偏移 offset 行 水平 错位' },
+  { section: 'desktopLyrics', title: '默认文字颜色 (Text Color)', terms: '文字 颜色 color 默认 歌词' },
+  { section: 'desktopLyrics', title: '高亮文字颜色 (Highlight Color)', terms: '高亮 颜色 highlight 歌词 当前' },
+  { section: 'desktopLyrics', title: '背景颜色 (Background Color)', terms: '背景 颜色 color 歌词' },
+  { section: 'desktopLyrics', title: '背景透明度 (Background Opacity)', terms: '背景 透明度 opacity 歌词 半透明' },
+  { section: 'desktopLyrics', title: '文字阴影 (Text Shadow)', terms: '文字 阴影 shadow 投影 歌词' },
+  { section: 'desktopLyrics', title: '阴影模糊度 (Shadow Blur)', terms: '阴影 模糊 blur 投影 歌词' },
+  { section: 'desktopLyrics', title: '阴影颜色 (Shadow Color)', terms: '阴影 颜色 shadow color 投影' },
+  { section: 'desktopLyrics', title: '对齐方式 (Alignment)', terms: '对齐 align 居左 居中 居右 歌词' },
+  { section: 'desktopLyrics', title: '窗口宽度 (Window Width)', terms: '窗口 宽度 width 桌面歌词' },
+  { section: 'desktopLyrics', title: '窗口高度 (Window Height)', terms: '窗口 高度 height 桌面歌词' },
+  { section: 'desktopLyrics', title: '始终置顶 (Always on Top)', terms: '置顶 always on top 窗口 顶层 钉住' },
+  { section: 'desktopLyrics', title: '鼠标穿透 (Click Through)', terms: '鼠标 穿透 click through 点击 穿透 窗口' },
+  { section: 'desktopLyrics', title: '布局模式 (Layout)', terms: '布局 layout 多行 双语 原文 翻译' },
+  { section: 'desktopLyrics', title: '显示翻译 (Show Translation)', terms: '翻译 translation 显示 双语 原文' },
+
+  // ── 快捷键 ────────────────────────────────────────────
+  { section: 'shortcuts', title: '全局快捷键 (Global Shortcuts)', terms: '全局 快捷键 系统 媒体键 后台 注册' },
+  { section: 'shortcuts', title: '快捷键状态', terms: '快捷键 状态 注册 冲突 检测 失败' },
+
+  // ── 关于 ──────────────────────────────────────────────
+  { section: 'about', title: '版本信息', match: 'Version', terms: '版本 version 关于 twilight echo 名称' },
+  { section: 'about', title: '检查更新', match: '检查更新', terms: '更新 update 检查 版本 下载 安装 发布' },
+  { section: 'about', title: '下载 / 安装更新', match: '更新', terms: '更新 下载 安装 版本 发布 github releases' },
+  { section: 'about', title: '支持项目发展', terms: '赞助 支持 捐赠 项目 开源 爱发电' },
+  { section: 'about', title: '开源致谢与交流群', match: '开源致谢', terms: '开源 致谢 交流 群 社区 感谢 license' }
+] satisfies SettingsSearchEntry[]).map((entry) => ({
+  ...entry,
+  terms: `${sectionTerms[entry.section]} ${entry.terms}`
+}))
 
 export const RESET_DESKTOP_LYRICS: DesktopLyricsSettings = {
   enabled: false,


### PR DESCRIPTION
## Release v1.0.3

### 🐛 Bug Fixes
- **fcitx5 Chinese input fix** (KDE Plasma Wayland)
  - Detects whether KWin has input method configured; if not, automatically restarts with `--ozone-platform=x11` fallback to restore fcitx5 Chinese input
  - Fixed IME composition event handling in `AnimatedInput` component: no longer discards input events during composition, and adds commit text handling for scenarios where `compositionend` is unreliable (X11/XIM)

### ✨ New Features
- **Settings search optimization**
  - Moved search box to the first position in the sidebar for quick access anytime
  - Built a settings‑item‑level search index (~80 entries), making every setting item searchable
  - Keyboard navigation for search results: `↑`/`↓` to cycle through results, `Enter` to jump, `Esc` to clear
  - Clicking a result precisely navigates to the corresponding setting item with a blinking highlight (2.2s)

### 🔧 Build
- Version bumped to `1.0.3`
- Linux executable renamed to `music`

### 📦 Artifacts (Linux x64)
| File | Description |
| --- | --- |
| `TwilightEcho-1.0.3.AppImage` | AppImage portable version |
| `TwilightEcho_1.0.3_amd64.deb` | Debian/Ubuntu package |
| `TwilightEcho-1.0.3.x86_64.rpm` | Fedora/openSUSE package |
| `TwilightEcho-1.0.3.tar.gz` | Archive package |