### PR TITLE
fix(player): distinct list-loop icon and volume global shortcuts (issue #18)

### DIFF
--- a/src/main/core/types.ts
+++ b/src/main/core/types.ts
@@ -24,6 +24,8 @@ export type PlayerShortcutAction =
   | 'playPause'
   | 'play'
   | 'pause'
+  | 'volumeUp'
+  | 'volumeDown'
   | { action: 'seek'; positionSeconds: number }
   | { action: 'setVolume'; volume: number }
   | { action: 'jumpQueue'; index: number }
@@ -260,5 +262,7 @@ export const PLAYER_SHORTCUTS: {
 }[] = [
   { accelerator: 'CommandOrControl+Alt+Left', action: 'previous', label: '上一首' },
   { accelerator: 'CommandOrControl+Alt+Right', action: 'next', label: '下一首' },
-  { accelerator: 'CommandOrControl+Alt+Space', action: 'playPause', label: '播放 / 暂停' }
+  { accelerator: 'CommandOrControl+Alt+Space', action: 'playPause', label: '播放 / 暂停' },
+  { accelerator: 'CommandOrControl+Alt+Up', action: 'volumeUp', label: '音量 +' },
+  { accelerator: 'CommandOrControl+Alt+Down', action: 'volumeDown', label: '音量 -' }
 ]

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -110,6 +110,8 @@ type PlayerShortcutAction =
   | 'playPause'
   | 'play'
   | 'pause'
+  | 'volumeUp'
+  | 'volumeDown'
   | { action: 'seek'; positionSeconds: number }
   | { action: 'setVolume'; volume: number }
   | { action: 'jumpQueue'; index: number }

--- a/src/preload/types.ts
+++ b/src/preload/types.ts
@@ -154,6 +154,8 @@ export type PlayerShortcutAction =
   | 'playPause'
   | 'play'
   | 'pause'
+  | 'volumeUp'
+  | 'volumeDown'
   | { action: 'seek'; positionSeconds: number }
   | { action: 'setVolume'; volume: number }
   | { action: 'jumpQueue'; index: number }

--- a/src/renderer/src/assets/icons/list-loop-repeat.svg
+++ b/src/renderer/src/assets/icons/list-loop-repeat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 24 24"><path fill="currentColor" d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/></svg>

--- a/src/renderer/src/components/PlayerBar.vue
+++ b/src/renderer/src/components/PlayerBar.vue
@@ -19,6 +19,7 @@ import pauseIcon from '../assets/icons/pause.svg'
 import playIcon from '../assets/icons/play.svg'
 import previousTrackIcon from '../assets/icons/previous-track.svg'
 import repeatIcon from '../assets/icons/single-song-repeat.svg'
+import listLoopIcon from '../assets/icons/list-loop-repeat.svg'
 import sequentialIcon from '../assets/icons/sequential-playback.svg'
 import shuffleIcon from '../assets/icons/shuffle.svg'
 import { useFavoriteButton } from './player-bar/useFavoriteButton'
@@ -1339,7 +1340,7 @@ onMounted(() => {
           @click="cyclePlayMode"
         >
           <img v-if="playMode === 'sequential'" :src="sequentialIcon" alt="顺序" />
-          <img v-else-if="playMode === 'listLoop'" :src="repeatIcon" alt="列表循环" />
+          <img v-else-if="playMode === 'listLoop'" :src="listLoopIcon" alt="列表循环" />
           <img v-else-if="playMode === 'repeat'" :src="repeatIcon" alt="单曲循环" />
           <img v-else :src="shuffleIcon" alt="随机" />
         </button>

--- a/src/renderer/src/stores/usePlayerStore.ts
+++ b/src/renderer/src/stores/usePlayerStore.ts
@@ -3412,6 +3412,14 @@ async function handlePlayerShortcutAction(
       if (isPlaying.value) await togglePlayState()
       return
     }
+    if (action === 'volumeUp') {
+      volume.value = Math.min(1, volume.value + 0.05)
+      return
+    }
+    if (action === 'volumeDown') {
+      volume.value = Math.max(0, volume.value - 0.05)
+      return
+    }
     // playPause
     await togglePlayState()
     return

--- a/src/renderer/src/types/settings.ts
+++ b/src/renderer/src/types/settings.ts
@@ -29,6 +29,8 @@ export type PlayerShortcutAction =
   | 'playPause'
   | 'play'
   | 'pause'
+  | 'volumeUp'
+  | 'volumeDown'
   | { action: 'seek'; positionSeconds: number }
   | { action: 'setVolume'; volume: number }
   | { action: 'jumpQueue'; index: number }


### PR DESCRIPTION
- 列表循环与单曲循环使用不同图标(新增 list-loop-repeat.svg)
- 新增全局快捷键 Ctrl+Alt+Up/Down 调节音量 +/-5%(设置页可查看注册状态)

Closes #18
