### PR TITLE
feat(ui): 优化卡片在窗口较小时的适配并限制窗口最小尺寸

### DIFF
--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -133,6 +133,8 @@ export function createWindow(): void {
   runtime.mainWindow = new BrowserWindow({
     width: 1495,
     height: 883,
+    minWidth: 1298,
+    minHeight: 692,
     show: false,
     frame: false,
     transparent: transparent && !acrylic,

--- a/src/renderer/src/components/LocalDashboard.css
+++ b/src/renderer/src/components/LocalDashboard.css
@@ -2386,6 +2386,91 @@
   }
 }
 
+@media (max-width: 640px) {
+  .fresh-grid,
+  .gallery-grid {
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+    gap: 16px 12px;
+  }
+
+  .fresh-name {
+    margin-top: 8px;
+    font-size: 12px;
+  }
+
+  .fresh-artist {
+    font-size: 11px;
+  }
+
+  .gallery-name {
+    margin-top: 9px;
+    font-size: 12px;
+  }
+
+  .gallery-artist {
+    font-size: 11px;
+  }
+
+  .fresh-play {
+    width: 30px;
+    height: 30px;
+    font-size: 11px;
+  }
+
+  .gallery-play {
+    width: 32px;
+    height: 32px;
+    font-size: 12px;
+  }
+
+  .gallery-count {
+    left: 8px;
+    bottom: 8px;
+    font-size: 10px;
+    padding: 2px 8px;
+  }
+
+  .masthead-title {
+    font-size: clamp(28px, 7vw, 34px);
+  }
+
+  .masthead-sub {
+    font-size: 13px;
+  }
+
+  .hero-title {
+    font-size: clamp(26px, 6.5vw, 30px);
+  }
+
+  .hero-artist {
+    font-size: 14px;
+  }
+
+  .hero-meta {
+    font-size: 11.5px;
+  }
+
+  .figure strong {
+    font-size: clamp(22px, 5vw, 26px);
+  }
+
+  .figure span {
+    font-size: 11.5px;
+  }
+
+  .signal-title h2 {
+    font-size: 18px;
+  }
+
+  .block-copy h3 {
+    font-size: 18px;
+  }
+
+  .block-copy p {
+    font-size: 11px;
+  }
+}
+
 /* ── Reduced motion ─────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/src/components/RadioPodcastPage.vue
+++ b/src/renderer/src/components/RadioPodcastPage.vue
@@ -588,6 +588,43 @@ button.primary {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 12px;
 }
+
+@media (max-width: 900px) {
+  .station-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 10px;
+  }
+
+  .station-card {
+    padding: 12px;
+    min-height: 108px;
+  }
+
+  .station-main strong {
+    font-size: 13px;
+  }
+
+  .station-main small {
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 640px) {
+  .station-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .station-card {
+    padding: 12px;
+    min-height: 0;
+  }
+
+  .station-actions button {
+    padding: 7px 10px;
+    font-size: 12px;
+  }
+}
 .station-card {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/components/StreamingDiscovery.vue
+++ b/src/renderer/src/components/StreamingDiscovery.vue
@@ -809,6 +809,51 @@ function emitPage(nextOffset: number): void {
   gap: 20px 18px;
 }
 
+@media (max-width: 900px) {
+  .disc-mosaic {
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+    gap: 14px 12px;
+  }
+
+  .disc-card-name {
+    font-size: 12.5px;
+  }
+
+  .disc-card-meta {
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 640px) {
+  .disc-mosaic {
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+    gap: 12px 10px;
+  }
+
+  .disc-card-name {
+    font-size: 11.5px;
+  }
+
+  .disc-card-meta {
+    font-size: 10.5px;
+  }
+
+  .disc-card-plays {
+    left: 6px;
+    bottom: 6px;
+    font-size: 9.5px;
+    padding: 2px 7px;
+  }
+
+  .disc-card-go {
+    right: 6px;
+    bottom: 6px;
+    width: 28px;
+    height: 28px;
+    font-size: 11px;
+  }
+}
+
 /* Featured cover story — spans a 2×2 cell of the wall */
 
 .disc-feature {

--- a/src/renderer/src/components/StreamingHome.vue
+++ b/src/renderer/src/components/StreamingHome.vue
@@ -1740,6 +1740,116 @@ function playPersonalizedStream(section: RecSection | null): void {
   }
 }
 
+@media (max-width: 640px) {
+  .hero-title {
+    font-size: clamp(30px, 8vw, 40px);
+  }
+
+  .hero-desc {
+    font-size: 13px;
+  }
+
+  .hero-actions {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .hero-play,
+  .hero-open {
+    height: 42px;
+    padding-inline: 18px;
+    font-size: 13px;
+  }
+
+  .duo-card {
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .duo-stack {
+    width: 80px;
+    height: 60px;
+  }
+
+  .duo-stack-cover {
+    width: 50px;
+    height: 50px;
+  }
+
+  .duo-stack-cover-1 {
+    left: 18px;
+  }
+
+  .duo-stack-cover-2 {
+    left: 34px;
+  }
+
+  .duo-name {
+    font-size: 17px;
+  }
+
+  .duo-sub {
+    font-size: 11px;
+  }
+
+  .shelf-grid,
+  .sk-tiles {
+    grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+    gap: 16px 12px;
+  }
+
+  .shelf-name {
+    margin-top: 8px;
+    font-size: 12px;
+  }
+
+  .shelf-count {
+    left: 8px;
+    bottom: 8px;
+    font-size: 10px;
+    padding: 2px 7px;
+  }
+
+  .shelf-open {
+    right: 8px;
+    bottom: 8px;
+    width: 30px;
+    height: 30px;
+    font-size: 11px;
+  }
+
+  .chart-row {
+    grid-template-columns: 28px 42px minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 8px 8px;
+  }
+
+  .chart-cover {
+    width: 42px;
+    height: 42px;
+  }
+
+  .chart-title {
+    font-size: 13px;
+  }
+
+  .chart-artist {
+    font-size: 11px;
+  }
+
+  .chart-duration {
+    font-size: 11px;
+  }
+
+  .section-head-copy h3 {
+    font-size: 18px;
+  }
+
+  .section-head-copy p {
+    font-size: 11px;
+  }
+}
+
 /* ══ Reduced motion ════════════════════════════════════════════════════ */
 
 @media (prefers-reduced-motion: reduce) {
@@ -1759,3 +1869,92 @@ function playPersonalizedStream(section: RecSection | null): void {
   }
 }
 </style>
+
+  .duo-card {
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .duo-stack {
+    width: 80px;
+    height: 60px;
+  }
+
+  .duo-stack-cover {
+    width: 50px;
+    height: 50px;
+  }
+
+  .duo-stack-cover-1 {
+    left: 18px;
+  }
+
+  .duo-stack-cover-2 {
+    left: 34px;
+  }
+
+  .duo-name {
+    font-size: 17px;
+  }
+
+  .duo-sub {
+    font-size: 11px;
+  }
+
+  .shelf-grid,
+  .sk-tiles {
+    grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+    gap: 16px 12px;
+  }
+
+  .shelf-name {
+    margin-top: 8px;
+    font-size: 12px;
+  }
+
+  .shelf-count {
+    left: 8px;
+    bottom: 8px;
+    font-size: 10px;
+    padding: 2px 7px;
+  }
+
+  .shelf-open {
+    right: 8px;
+    bottom: 8px;
+    width: 30px;
+    height: 30px;
+    font-size: 11px;
+  }
+
+  .chart-row {
+    grid-template-columns: 28px 42px minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 8px 8px;
+  }
+
+  .chart-cover {
+    width: 42px;
+    height: 42px;
+  }
+
+  .chart-title {
+    font-size: 13px;
+  }
+
+  .chart-artist {
+    font-size: 11px;
+  }
+
+  .chart-duration {
+    font-size: 11px;
+  }
+
+  .section-head-copy h3 {
+    font-size: 18px;
+  }
+
+  .section-head-copy p {
+    font-size: 11px;
+  }
+}

--- a/src/renderer/src/components/StreamingLibrary.vue
+++ b/src/renderer/src/components/StreamingLibrary.vue
@@ -994,6 +994,25 @@ function deletePlaylistLabel(playlist: MediaProviderPlaylistSummary): string {
   gap: 24px;
 }
 
+@media (max-width: 900px) {
+  .playlist-grid {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 18px;
+  }
+
+  .glass-card {
+    padding: 24px;
+  }
+
+  .profile-info h1 {
+    font-size: 24px;
+  }
+
+  .favorites-info h2 {
+    font-size: 22px;
+  }
+}
+
 .playlist-item {
   display: flex;
   align-items: center;
@@ -1326,6 +1345,28 @@ function deletePlaylistLabel(playlist: MediaProviderPlaylistSummary): string {
 }
 
 @media (max-width: 720px) {
+  .playlist-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 14px;
+  }
+
+  .glass-card {
+    padding: 20px;
+  }
+
+  .playlist-item-title {
+    font-size: 14px;
+  }
+
+  .playlist-item-count {
+    font-size: 12px;
+  }
+
+  .playlist-item-cover {
+    width: 52px;
+    height: 52px;
+  }
+
   .profile-card,
   .favorites-card,
   .feature-card {

--- a/src/renderer/src/components/StreamingSearch.vue
+++ b/src/renderer/src/components/StreamingSearch.vue
@@ -581,6 +581,48 @@ function emitPage(first: number): void {
   margin-top: 0;
 }
 
+@media (max-width: 900px) {
+  .playlist-grid {
+    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+    gap: 12px 10px;
+  }
+
+  .playlist-grid-card {
+    padding: 9px;
+  }
+
+  .playlist-grid-name {
+    margin-top: 9px;
+    font-size: 12.5px;
+  }
+
+  .playlist-grid-count {
+    margin-top: 3px;
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 640px) {
+  .playlist-grid {
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+    gap: 10px 8px;
+  }
+
+  .playlist-grid-card {
+    padding: 7px;
+  }
+
+  .playlist-grid-name {
+    margin-top: 7px;
+    font-size: 11.5px;
+  }
+
+  .playlist-grid-count {
+    margin-top: 2px;
+    font-size: 10.5px;
+  }
+}
+
 .playlist-grid-card {
   cursor: pointer;
   padding: 12px;

--- a/src/renderer/src/components/song-list/SongList.css
+++ b/src/renderer/src/components/song-list/SongList.css
@@ -736,6 +736,22 @@
   padding: 2px 2px 8px;
 }
 
+/* Narrow-window adaptation: shrink card columns and inner text so cards
+   stay usable without overflowing or becoming oversized. */
+@media (max-width: 900px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+    gap: 16px 14px;
+  }
+}
+
+@media (max-width: 640px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+    gap: 12px 10px;
+  }
+}
+
 /* Unified Card Component Styles */
 .artist-card,
 .album-card,
@@ -743,6 +759,7 @@
   display: flex;
   flex-direction: column;
   padding: 13px 13px 15px;
+  min-width: 0;
   border-radius: 18px;
   background:
     linear-gradient(145deg, rgba(255, 255, 255, 0.56), rgba(248, 245, 255, 0.34)),
@@ -759,6 +776,22 @@
   -webkit-backdrop-filter: blur(20px) saturate(150%);
   overflow: hidden;
   position: relative;
+}
+
+@media (max-width: 900px) {
+  .artist-card,
+  .album-card,
+  .playlist-card {
+    padding: 10px 10px 12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .artist-card,
+  .album-card,
+  .playlist-card {
+    padding: 8px 8px 10px;
+  }
 }
 
 .artist-card::before,
@@ -870,6 +903,42 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+@media (max-width: 900px) {
+  .artist-name,
+  .album-name,
+  .playlist-name {
+    font-size: 13px;
+  }
+
+  .artist-count,
+  .album-count,
+  .playlist-count {
+    font-size: 11px;
+  }
+
+  .playlist-source-summary {
+    font-size: 10.5px;
+  }
+}
+
+@media (max-width: 640px) {
+  .artist-name,
+  .album-name,
+  .playlist-name {
+    font-size: 12px;
+  }
+
+  .artist-count,
+  .album-count,
+  .playlist-count {
+    font-size: 10.5px;
+  }
+
+  .playlist-source-summary {
+    font-size: 10px;
+  }
 }
 
 /* Empty State */

--- a/src/renderer/src/components/streaming-page/StreamingPage.css
+++ b/src/renderer/src/components/streaming-page/StreamingPage.css
@@ -2896,3 +2896,69 @@
 :global(html[data-theme='dark'] .streaming-context-menu .menu-item:hover) {
   background: rgba(129, 140, 248, 0.16);
 }
+
+/* ── Narrow-window adaptation ────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .playlist-grid {
+    grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+    gap: 12px 10px;
+  }
+
+  .playlist-grid-card {
+    padding: 9px;
+  }
+
+  .playlist-grid-name {
+    margin-top: 9px;
+    font-size: 12.5px;
+  }
+
+  .playlist-grid-count {
+    margin-top: 3px;
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 640px) {
+  .playlist-grid {
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+    gap: 10px 8px;
+  }
+
+  .playlist-grid-card {
+    padding: 7px;
+  }
+
+  .playlist-grid-name {
+    margin-top: 7px;
+    font-size: 11.5px;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .playlist-grid-count {
+    margin-top: 2px;
+    font-size: 10.5px;
+  }
+
+  .detail-playlist-header {
+    gap: 14px;
+    padding: 14px;
+    min-height: 0;
+  }
+
+  .detail-playlist-cover,
+  .detail-playlist-cover-placeholder {
+    width: 104px;
+    height: 104px;
+  }
+
+  .detail-playlist-name {
+    font-size: clamp(17px, 4.4vw, 22px);
+    margin-bottom: 8px;
+  }
+
+  .detail-playlist-desc {
+    font-size: 12.5px;
+  }
+}


### PR DESCRIPTION
## 变更内容

优化卡片在窗口较小时的适配，并限制窗口最小尺寸。

### 主要改动

- **窗口适配**：所有卡片网格在小窗口下逐级缩小列宽与内边距
- **文字缩放**：卡片内部文字（名称/数量/描述）随断点同步缩小
- **最小尺寸**：主窗口最小尺寸限制为 1298x692

### 涉及文件

- `src/main/app/window.ts` - 窗口最小尺寸限制
- `src/renderer/src/components/LocalDashboard.css` - 本地仪表盘卡片适配
- `src/renderer/src/components/RadioPodcastPage.vue` - 电台/播客页面适配
- `src/renderer/src/components/StreamingDiscovery.vue` - 发现页适配
- `src/renderer/src/components/StreamingHome.vue` - 首页适配
- `src/renderer/src/components/StreamingLibrary.vue` - 音乐库适配
- `src/renderer/src/components/StreamingSearch.vue` - 搜索页适配
- `src/renderer/src/components/song-list/SongList.css` - 歌曲列表适配
- `src/renderer/src/components/streaming-page/StreamingPage.css` - 流媒体页面适配

### 提交

- `04217ab` feat(ui): 优化卡片在窗口较小时的适配并限制窗口最小尺寸
- `4b9d288` feat(ui): 补充一个漏提交的文件