### PR TITLE
更好的桌面歌词

### DIFF
--- a/resources/desktop-lyrics.html
+++ b/resources/desktop-lyrics.html
@@ -33,16 +33,38 @@
         align-items: center;
         justify-content: center;
         gap: 4px;
-        transition: background 0.3s ease;
         border-radius: 12px;
         position: relative;
+        background: transparent;
         -webkit-app-region: drag;
+      }
+      #lyrics-container::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: var(--dl-acrylic-bg, transparent);
+        opacity: 0;
+        pointer-events: none;
+        z-index: 0;
+        transition: opacity 0.22s ease;
+      }
+      #lyrics-container.show-acrylic::before {
+        opacity: 1;
+        backdrop-filter: blur(18px) saturate(1.35);
+        -webkit-backdrop-filter: blur(18px) saturate(1.35);
       }
       #lyrics-container.dragging {
         cursor: grabbing;
       }
-      #lyrics-container:not(.dragging) {
+      #lyrics-container:not(.dragging):not(.locked) {
         cursor: grab;
+      }
+      #lyrics-content,
+      #toolbar,
+      #song-info {
+        position: relative;
+        z-index: 1;
       }
 
       #toolbar {
@@ -62,12 +84,51 @@
         z-index: 100;
         -webkit-app-region: no-drag;
       }
-      #lyrics-container:hover #toolbar,
-      #lyrics-container:focus-within #toolbar,
-      #lyrics-container.locked.temp-unlocked #toolbar {
+      #lyrics-container.hovered:not(.locked) #toolbar,
+      #lyrics-container.selected:not(.locked) #toolbar,
+      #lyrics-container:focus-within:not(.locked) #toolbar {
         opacity: 1;
         pointer-events: auto;
         transform: translateY(0);
+      }
+      #lyrics-container.locked #toolbar {
+        top: 50%;
+        left: 50%;
+        right: auto;
+        align-items: center;
+        transform: translate(-50%, calc(-50% - 4px));
+      }
+      #lyrics-container.locked.hovered #toolbar {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translate(-50%, -50%);
+      }
+      #lyrics-container.locked #toolbar .toolbar-surface > :not(#btn-lock),
+      #lyrics-container.locked #color-panel {
+        display: none;
+      }
+      #lyrics-container.locked #toolbar .toolbar-surface {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        padding: 0;
+        min-height: 0;
+        max-width: none;
+      }
+      #lyrics-container.locked #btn-lock {
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        background: rgba(16, 18, 24, 0.55);
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
+      }
+      #lyrics-container.locked #btn-lock:hover {
+        background: rgba(16, 18, 24, 0.78);
+      }
+      .toolbar-btn.active {
+        background: rgba(255, 255, 255, 0.28);
       }
       .toolbar-surface {
         display: flex;
@@ -329,22 +390,17 @@
         transition: opacity 0.25s ease;
         pointer-events: none;
       }
-      #lyrics-container:hover #song-info {
+      #lyrics-container.hovered:not(.locked) #song-info,
+      #lyrics-container.selected:not(.locked) #song-info {
         opacity: 1;
       }
       #lyrics-container.locked {
         cursor: default;
         -webkit-app-region: no-drag;
       }
-      #lyrics-container.locked #toolbar,
       #lyrics-container.locked #song-info {
         opacity: 0;
         pointer-events: none;
-      }
-      #lyrics-container.locked.temp-unlocked #toolbar,
-      #lyrics-container.locked.temp-unlocked #song-info {
-        opacity: 1;
-        pointer-events: auto;
       }
     </style>
   </head>
@@ -415,6 +471,19 @@
             <option value="center">居中</option>
             <option value="left">靠左</option>
           </select>
+          <button
+            class="toolbar-btn"
+            id="btn-acrylic"
+            title="隐藏亚克力背景"
+            aria-label="隐藏亚克力背景"
+            aria-pressed="true"
+          >
+            <svg viewBox="0 0 24 24">
+              <path
+                d="M5 5h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2zm1 3v8h12V8zm3 2h6v4H9z"
+              />
+            </svg>
+          </button>
           <button class="toolbar-btn" id="btn-lock" title="锁定桌面歌词" aria-label="锁定桌面歌词">
             <svg viewBox="0 0 24 24">
               <path
@@ -480,6 +549,7 @@
         var songInfoEl = document.getElementById('song-info')
         var btnClose = document.getElementById('btn-close')
         var btnLock = document.getElementById('btn-lock')
+        var btnAcrylic = document.getElementById('btn-acrylic')
         var btnFontDecrease = document.getElementById('btn-font-decrease')
         var btnFontIncrease = document.getElementById('btn-font-increase')
         var btnColor = document.getElementById('btn-color')
@@ -808,20 +878,19 @@
           container.style.fontSize = s.fontSize + 'px'
           container.style.fontWeight = String(s.fontWeight)
 
-          var bgAlpha = s.bgOpacity / 100
-          container.style.background =
-            s.bgOpacity > 0 ? hexToRgba(s.bgColor, bgAlpha) : 'transparent'
-
           container.style.textAlign = s.align
           container.style.justifyContent = 'center'
           container.style.alignItems = 'center'
           contentEl.style.alignItems = s.align === 'left' ? 'flex-start' : 'center'
           container.classList.toggle('netease', s.presentation !== 'classic')
-          container.classList.toggle('locked', s.locked === true)
-          container.classList.toggle('temp-unlocked', s.locked === true && tempInteractive)
           container.style.setProperty('--dl-highlight', s.highlightColor)
           btnLock.title = s.locked ? '解锁桌面歌词' : '锁定桌面歌词'
           btnLock.setAttribute('aria-label', btnLock.title)
+          var acrylicOn = s.showAcrylic !== false
+          btnAcrylic.classList.toggle('active', acrylicOn)
+          btnAcrylic.title = acrylicOn ? '隐藏亚克力背景' : '显示亚克力背景'
+          btnAcrylic.setAttribute('aria-label', btnAcrylic.title)
+          btnAcrylic.setAttribute('aria-pressed', acrylicOn ? 'true' : 'false')
           fontSelect.value = s.fontFamily || 'system'
           if (!fontSelect.value) appendInstalledFontOption(s.fontFamily)
           fontSelect.value = s.fontFamily || 'system'
@@ -834,7 +903,7 @@
           opacityBackground.value = String(s.bgOpacity)
           opacityBackgroundValue.textContent = s.bgOpacity + '%'
           document.getElementById('color-swatch').style.background = s.highlightColor
-          updateTempInteraction()
+          syncChrome()
 
           renderLines()
         }
@@ -1160,39 +1229,110 @@
           })
           .catch(function () {})
 
-        var tempInteractive = false
+        var selected = false
+        var hovered = false
+        var pointerOver = false
+        var hoverRevealTimer = null
         var pendingInteractiveValue = false
-        function updateTempInteraction() {
-          if (tempInteractive === pendingInteractiveValue) return
-          pendingInteractiveValue = tempInteractive
-          api.setInteractive(tempInteractive)
+        var HOVER_REVEAL_DELAY_MS = 2000
+
+        function clearHoverRevealTimer() {
+          if (hoverRevealTimer == null) return
+          clearTimeout(hoverRevealTimer)
+          hoverRevealTimer = null
         }
 
-        function shouldShowUnlockAffordance(event) {
-          var rect = toolbar.getBoundingClientRect()
-          return (
-            event.clientX >= rect.left - 12 &&
-            event.clientX <= rect.right + 12 &&
-            event.clientY >= rect.top - 12 &&
-            event.clientY <= rect.bottom + 12
+        function setPointerOver(over) {
+          pointerOver = over === true
+          if (!pointerOver) {
+            clearHoverRevealTimer()
+            hovered = false
+            syncChrome()
+            return
+          }
+          if (!settings || !settings.locked) {
+            clearHoverRevealTimer()
+            hovered = true
+            syncChrome()
+            return
+          }
+          if (hovered) {
+            syncChrome()
+            return
+          }
+          if (hoverRevealTimer != null) return
+          hoverRevealTimer = setTimeout(function () {
+            hoverRevealTimer = null
+            if (!pointerOver || !settings || !settings.locked) return
+            hovered = true
+            syncChrome()
+          }, HOVER_REVEAL_DELAY_MS)
+        }
+
+        function revealLockedChrome() {
+          if (!settings || !settings.locked) return
+          clearHoverRevealTimer()
+          hovered = true
+          syncChrome()
+        }
+
+        function acrylicEnabled() {
+          return !settings || settings.showAcrylic !== false
+        }
+
+        function applyAcrylicBackground() {
+          if (!settings || !container.classList.contains('show-acrylic')) {
+            container.style.setProperty('--dl-acrylic-bg', 'transparent')
+            return
+          }
+          var bgAlpha = settings.bgOpacity / 100
+          container.style.setProperty(
+            '--dl-acrylic-bg',
+            settings.bgOpacity > 0 ? hexToRgba(settings.bgColor, bgAlpha) : 'rgba(16, 18, 24, 0.28)'
           )
         }
 
-        document.addEventListener('pointermove', function (event) {
-          if (!settings || !settings.locked) return
-          var next = shouldShowUnlockAffordance(event)
-          if (next !== tempInteractive) {
-            tempInteractive = next
-            container.classList.toggle('temp-unlocked', next)
-            updateTempInteraction()
+        function syncChrome() {
+          var locked = Boolean(settings && settings.locked)
+          if (locked) selected = false
+          container.classList.toggle('locked', locked)
+          container.classList.toggle('selected', !locked && selected)
+          container.classList.toggle('hovered', hovered)
+          container.classList.toggle('show-acrylic', !locked && selected && acrylicEnabled())
+          applyAcrylicBackground()
+          var wantInteractive = locked ? pointerOver : true
+          if (wantInteractive !== pendingInteractiveValue) {
+            pendingInteractiveValue = wantInteractive
+            api.setInteractive(wantInteractive)
           }
+        }
+
+        document.addEventListener('pointerenter', function () {
+          setPointerOver(true)
         })
         document.addEventListener('pointerleave', function () {
-          if (!settings || !settings.locked || !tempInteractive) return
-          tempInteractive = false
-          container.classList.remove('temp-unlocked')
-          updateTempInteraction()
+          setPointerOver(false)
         })
+        container.addEventListener('pointerdown', function (event) {
+          if (!settings || settings.locked) return
+          if (event.target && event.target.closest && event.target.closest('#toolbar')) return
+          selected = true
+          syncChrome()
+        })
+        container.addEventListener('dblclick', function (event) {
+          if (!settings || !settings.locked) return
+          if (event.target && event.target.closest && event.target.closest('#toolbar')) return
+          revealLockedChrome()
+        })
+        window.addEventListener('blur', function () {
+          selected = false
+          syncChrome()
+        })
+        if (typeof api.onHoverIntent === 'function') {
+          api.onHoverIntent(function (over) {
+            setPointerOver(over === true)
+          })
+        }
 
         // ── IPC via window.api ──
         api.onInitSettings(function (s) {
@@ -1267,15 +1407,17 @@
         document.addEventListener('click', function () {
           setColorPanelOpen(false)
         })
+        btnAcrylic.addEventListener('click', function (event) {
+          event.stopPropagation()
+          if (!settings) return
+          updateSettingsPatch({ showAcrylic: settings.showAcrylic === false })
+        })
         btnLock.addEventListener('click', function () {
           if (!settings) return
           var nextLocked = !settings.locked
+          selected = !nextLocked
+          hovered = true
           updateSettingsPatch({ locked: nextLocked, clickThrough: nextLocked })
-          if (!nextLocked && tempInteractive) {
-            tempInteractive = false
-            container.classList.remove('temp-unlocked')
-            updateTempInteraction()
-          }
         })
       })()
     </script>

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -99,6 +99,7 @@ export const DEFAULT_DESKTOP_LYRICS: DesktopLyricsSettings = {
   highlightColor: '#3b82f6',
   bgColor: '#000000',
   bgOpacity: 30,
+  showAcrylic: true,
   align: 'center',
   showTranslation: true,
   layout: 'bilingual',
@@ -655,6 +656,7 @@ export function normalizeDesktopLyrics(raw: unknown): DesktopLyricsSettings {
         : DEFAULT_DESKTOP_LYRICS.highlightColor,
     bgColor: typeof d.bgColor === 'string' ? d.bgColor : DEFAULT_DESKTOP_LYRICS.bgColor,
     bgOpacity: clampNumber(d.bgOpacity, 0, 100, DEFAULT_DESKTOP_LYRICS.bgOpacity),
+    showAcrylic: d.showAcrylic !== false,
     align: d.align === 'left' ? 'left' : 'center',
     showTranslation: d.showTranslation !== false,
     layout:

--- a/src/main/integrations/desktopLyrics.test.ts
+++ b/src/main/integrations/desktopLyrics.test.ts
@@ -99,10 +99,20 @@ test('desktop lyrics retain legacy click-through state as hover-unlock locking',
   )
 
   assert.match(settings, /locked:\s*\n?\s*typeof d\.locked === 'boolean'/)
+  assert.match(settings, /showAcrylic: d\.showAcrylic !== false/)
   assert.match(source, /applyDesktopLyricsMouseMode/)
   assert.match(source, /setIgnoreMouseEvents\(shouldIgnoreMouseEvents,\s*\{\s*forward:\s*true\s*\}/)
+  assert.match(source, /desktopLyrics:hoverIntent/)
+  assert.match(source, /getCursorScreenPoint/)
   assert.match(renderer, /TwilightDesktopLyricsPresentation\.resolveNetEaseRows/)
   assert.match(renderer, /desktopLyrics:setInteractive|api\.setInteractive/)
+  assert.match(renderer, /id="btn-acrylic"/)
+  assert.match(renderer, /classList\.toggle\('show-acrylic'/)
+  assert.match(renderer, /#lyrics-container\.locked #toolbar \.toolbar-surface > :not\(#btn-lock\)/)
+  assert.match(renderer, /#lyrics-container\.locked #toolbar \{[\s\S]*left:\s*50%/)
+  assert.match(renderer, /transform:\s*translate\(-50%,\s*-50%\)/)
+  assert.match(renderer, /HOVER_REVEAL_DELAY_MS = 2000/)
+  assert.match(renderer, /addEventListener\('dblclick'/)
 })
 
 test('desktop lyrics presentation survives settings normalization after restart', async () => {

--- a/src/main/integrations/desktopLyrics.ts
+++ b/src/main/integrations/desktopLyrics.ts
@@ -9,12 +9,73 @@ import { createSettingsSnapshot, normalizeDesktopLyrics, writeAppSettings } from
 import { assertTrustedIpcSender, shouldAcceptIpcEvent } from '../security/electronSecurity.ts'
 
 let moveSaveTimer: NodeJS.Timeout | null = null
+let hoverWatchTimer: NodeJS.Timeout | null = null
 let temporarilyInteractive = false
+let lastHoverIntent = false
 
 function clearMoveSaveTimer(): void {
   if (!moveSaveTimer) return
   clearTimeout(moveSaveTimer)
   moveSaveTimer = null
+}
+
+function stopLockedHoverWatch(): void {
+  if (!hoverWatchTimer) return
+  clearInterval(hoverWatchTimer)
+  hoverWatchTimer = null
+  lastHoverIntent = false
+}
+
+function sendHoverIntent(over: boolean): void {
+  const win = runtime.desktopLyricsWindow
+  if (!win || win.isDestroyed()) return
+  if (lastHoverIntent === over) return
+  lastHoverIntent = over
+  win.webContents.send('desktopLyrics:hoverIntent', over)
+}
+
+function pollLockedCursor(): void {
+  const win = runtime.desktopLyricsWindow
+  if (!win || win.isDestroyed()) {
+    stopLockedHoverWatch()
+    temporarilyInteractive = false
+    return
+  }
+  if (!runtime.appSettings.desktopLyrics.locked) {
+    if (temporarilyInteractive) {
+      temporarilyInteractive = false
+      applyDesktopLyricsMouseMode()
+    }
+    sendHoverIntent(false)
+    return
+  }
+  const point = screen.getCursorScreenPoint()
+  const bounds = win.getBounds()
+  const over =
+    point.x >= bounds.x &&
+    point.x < bounds.x + bounds.width &&
+    point.y >= bounds.y &&
+    point.y < bounds.y + bounds.height
+  if (over !== temporarilyInteractive) {
+    temporarilyInteractive = over
+    applyDesktopLyricsMouseMode()
+  }
+  sendHoverIntent(over)
+}
+
+function startLockedHoverWatch(): void {
+  if (hoverWatchTimer) return
+  pollLockedCursor()
+  hoverWatchTimer = setInterval(pollLockedCursor, 80)
+}
+
+function syncLockedHoverWatch(): void {
+  const win = runtime.desktopLyricsWindow
+  if (!win || win.isDestroyed() || !runtime.appSettings.desktopLyrics.locked) {
+    stopLockedHoverWatch()
+    return
+  }
+  startLockedHoverWatch()
 }
 
 function persistDesktopLyricsPosition(win: BrowserWindow): void {
@@ -51,6 +112,7 @@ export function syncDesktopLyricsSettings(): void {
   const settings = runtime.appSettings.desktopLyrics
   win.setAlwaysOnTop(settings.alwaysOnTop, 'screen-saver')
   applyDesktopLyricsMouseMode()
+  syncLockedHoverWatch()
   if (
     settings.windowWidth !== win.getBounds().width ||
     settings.windowHeight !== win.getBounds().height
@@ -113,6 +175,7 @@ function createDesktopLyricsWindow(): void {
 
   runtime.desktopLyricsWindow.setAlwaysOnTop(dl.alwaysOnTop, 'screen-saver')
   applyDesktopLyricsMouseMode()
+  syncLockedHoverWatch()
 
   runtime.desktopLyricsWindow.on('ready-to-show', () => {
     runtime.desktopLyricsWindow?.show()
@@ -121,6 +184,7 @@ function createDesktopLyricsWindow(): void {
 
   runtime.desktopLyricsWindow.on('closed', () => {
     clearMoveSaveTimer()
+    stopLockedHoverWatch()
     temporarilyInteractive = false
     runtime.desktopLyricsWindow = null
   })
@@ -169,6 +233,8 @@ export function showDesktopLyrics(): void {
 export function destroyDesktopLyrics(): void {
   const win = runtime.desktopLyricsWindow
   clearMoveSaveTimer()
+  stopLockedHoverWatch()
+  temporarilyInteractive = false
   if (!win || win.isDestroyed()) {
     runtime.desktopLyricsWindow = null
     return

--- a/src/preload/domains/desktopLyricsApi.ts
+++ b/src/preload/domains/desktopLyricsApi.ts
@@ -9,6 +9,7 @@ const desktopLyricsSettingsUpdateCallbacks = new Set<(settings: DesktopLyricsSet
 const desktopLyricsLoadFailedCallbacks = new Set<
   (payload: { code: number; description: string }) => void
 >()
+const desktopLyricsHoverIntentCallbacks = new Set<(over: boolean) => void>()
 
 export function bindDesktopLyricsIpcEvents(): void {
   ipcRenderer.on('desktopLyrics:toggleChanged', (_event, enabled: boolean) => {
@@ -49,6 +50,12 @@ export function bindDesktopLyricsIpcEvents(): void {
       }
     }
   )
+
+  ipcRenderer.on('desktopLyrics:hoverIntent', (_event, over: boolean) => {
+    for (const cb of desktopLyricsHoverIntentCallbacks) {
+      cb(over === true)
+    }
+  })
 }
 
 export const desktopLyricsApi = {
@@ -91,6 +98,10 @@ export const desktopLyricsApi = {
   onLoadFailed: (cb: (payload: { code: number; description: string }) => void): (() => void) => {
     desktopLyricsLoadFailedCallbacks.add(cb)
     return () => desktopLyricsLoadFailedCallbacks.delete(cb)
+  },
+  onHoverIntent: (cb: (over: boolean) => void): (() => void) => {
+    desktopLyricsHoverIntentCallbacks.add(cb)
+    return () => desktopLyricsHoverIntentCallbacks.delete(cb)
   },
   getPosition: (): void => {
     ipcRenderer.send('desktopLyrics:getPosition')

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1243,6 +1243,7 @@ interface WindowAPI {
     onTimeUpdate: (cb: (time: number) => void) => () => void
     onSettingsUpdate: (cb: (settings: DesktopLyricsSettings) => void) => () => void
     onLoadFailed: (cb: (payload: { code: number; description: string }) => void) => () => void
+    onHoverIntent: (cb: (over: boolean) => void) => () => void
     getPosition: () => void
     move: (x: number, y: number) => void
     requestClose: () => void

--- a/src/renderer/src/components/settings-page/DesktopLyricsSettingsSection.vue
+++ b/src/renderer/src/components/settings-page/DesktopLyricsSettingsSection.vue
@@ -380,6 +380,23 @@ async function toggleFontMenu(): Promise<void> {
       <hr />
       <div class="setting-item">
         <div class="setting-copy">
+          <strong>选中时显示亚克力 (Acrylic)</strong>
+          <span>点击歌词选中后才显示毛玻璃背景；关闭后选中也只显示歌词和控制条。</span>
+        </div>
+        <span
+          class="toggle-switch"
+          :class="{
+            active: props.desktopLyrics.showAcrylic !== false,
+            inactive: props.desktopLyrics.showAcrylic === false
+          }"
+          role="switch"
+          :aria-checked="props.desktopLyrics.showAcrylic !== false"
+          @click="update('showAcrylic', props.desktopLyrics.showAcrylic === false)"
+        ></span>
+      </div>
+      <hr />
+      <div class="setting-item">
+        <div class="setting-copy">
           <strong>文字阴影 (Text Shadow)</strong>
           <span>为歌词文字添加阴影以提高辨识度。</span>
         </div>
@@ -522,7 +539,7 @@ async function toggleFontMenu(): Promise<void> {
       <div class="setting-item">
         <div class="setting-copy">
           <strong>锁定桌面歌词 (Lock)</strong>
-          <span>开启后点击穿透桌面；把鼠标移到歌词右上角可显示解锁按钮。</span>
+          <span>开启后点击穿透桌面；双击或悬浮歌词约 2 秒后在正中显示小锁，点锁即可解锁编辑。</span>
         </div>
         <span
           class="toggle-switch"

--- a/src/renderer/src/components/settings-page/types.ts
+++ b/src/renderer/src/components/settings-page/types.ts
@@ -650,6 +650,11 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = (
     },
     {
       section: 'desktopLyrics',
+      title: '选中时显示亚克力 (Acrylic)',
+      terms: '亚克力 acrylic 毛玻璃 背景 选中 隐藏 开关'
+    },
+    {
+      section: 'desktopLyrics',
       title: '文字阴影 (Text Shadow)',
       terms: '文字 阴影 shadow 投影 歌词'
     },
@@ -685,8 +690,8 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = (
     },
     {
       section: 'desktopLyrics',
-      title: '鼠标穿透 (Click Through)',
-      terms: '鼠标 穿透 click through 点击 穿透 窗口'
+      title: '锁定桌面歌词 (Lock)',
+      terms: '锁定 lock 小锁 穿透 click through 双击 悬浮 2秒 解锁'
     },
     {
       section: 'desktopLyrics',
@@ -758,6 +763,7 @@ export const RESET_DESKTOP_LYRICS: DesktopLyricsSettings = {
   highlightColor: '#3b82f6',
   bgColor: '#000000',
   bgOpacity: 30,
+  showAcrylic: true,
   align: 'center',
   showTranslation: true,
   layout: 'bilingual',

--- a/src/shared/appSettings.ts
+++ b/src/shared/appSettings.ts
@@ -106,6 +106,7 @@ export interface DesktopLyricsSettings {
   highlightColor: string
   bgColor: string
   bgOpacity: number
+  showAcrylic: boolean
   align: LyricAlign
   showTranslation: boolean
   /** multi = consecutive lines; bilingual = original + translation for the active line. */


### PR DESCRIPTION
改进桌面歌词交互：

- 平时只显示歌词；点击歌词后才选中，并显示字号、居中、颜色、锁定等控制条
- 亚克力毛玻璃仅在选中时出现，设置里可关闭
- 锁定后点击穿透；悬浮约 2 秒或双击歌词后，在正中显示小锁，点锁即可解锁编辑