### PR TITLE
fix(mac): package a portable signed audio runtime

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -75,8 +75,11 @@ jobs:
 
       - name: Verify staged native engine in the packaged app
         run: |
-          find dist -path '*/TwilightEcho.app/Contents/Resources/audio-engine/libtwilight-audio-engine.dylib' -type f -print -quit | grep -q .
-          find dist -path '*/TwilightEcho.app/Contents/Resources/audio-engine/twilight_audio_node.node' -type f -print -quit | grep -q .
+          runtime_dir="$(find dist -path '*/TwilightEcho.app/Contents/Resources/audio-engine' -type d -print -quit)"
+          test -n "$runtime_dir"
+          test -f "$runtime_dir/libtwilight-audio-engine.dylib"
+          test -f "$runtime_dir/twilight_audio_node.node"
+          node scripts/macos-audio-runtime.cjs --runtime-dir "$runtime_dir"
 
       - name: Upload macOS packages
         uses: actions/upload-artifact@v4

--- a/audio-engine/CMakeLists.txt
+++ b/audio-engine/CMakeLists.txt
@@ -246,6 +246,11 @@ if(TAE_ALSA_AVAILABLE)
 endif()
 
 if(TAE_BUILD_NAPI)
+  if(APPLE)
+    set(TAE_NAPI_RPATH "@loader_path")
+  else()
+    set(TAE_NAPI_RPATH "$ORIGIN")
+  endif()
   add_library(twilight_audio_node MODULE napi/twilight_audio_node.cpp)
   if(WIN32)
     target_sources(twilight_audio_node PRIVATE napi/node_api_dynamic_win32.cpp)
@@ -256,8 +261,8 @@ if(TAE_BUILD_NAPI)
   set_target_properties(twilight_audio_node PROPERTIES
     PREFIX ""
     SUFFIX ".node"
-    BUILD_RPATH "$ORIGIN"
-    INSTALL_RPATH "$ORIGIN"
+    BUILD_RPATH "${TAE_NAPI_RPATH}"
+    INSTALL_RPATH "${TAE_NAPI_RPATH}"
   )
   if(APPLE)
     target_link_options(twilight_audio_node PRIVATE "-undefined" "dynamic_lookup")

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
   </dict>

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "verify:install-policy": "node scripts/verify-install-policy.cjs",
     "verify:ncm-patch": "node scripts/verify-ncm-patch.cjs",
     "verify:asio-sdk-free": "node scripts/verify-asio-sdk-free.cjs",
-    "test:release-artifacts": "node --test scripts/verify-install-policy.test.cjs scripts/release-artifact-strip.test.cjs scripts/verify-release-artifacts.test.cjs scripts/verify-release-capability-consistency.test.cjs scripts/staged-audio-runtime-observation.test.cjs scripts/release-delivery-policy.test.cjs scripts/verify-packaged-dependency-closure.test.cjs scripts/verify-windows-app-branding.test.cjs",
+    "test:release-artifacts": "node --test scripts/verify-install-policy.test.cjs scripts/release-artifact-strip.test.cjs scripts/verify-release-artifacts.test.cjs scripts/verify-release-capability-consistency.test.cjs scripts/staged-audio-runtime-observation.test.cjs scripts/release-delivery-policy.test.cjs scripts/verify-packaged-dependency-closure.test.cjs scripts/verify-windows-app-branding.test.cjs scripts/macos-audio-runtime.test.cjs",
     "verify:release-artifacts": "node scripts/verify-release-artifacts.cjs",
     "verify:packaged-dependencies": "node scripts/verify-packaged-dependency-closure.cjs dist/win-unpacked/resources/app.asar",
     "verify:renderer-budgets": "node scripts/verify-renderer-budgets.cjs --renderer-dir out/renderer",

--- a/scripts/audio-engine-toolchain.test.cjs
+++ b/scripts/audio-engine-toolchain.test.cjs
@@ -39,6 +39,7 @@ const { createMinimalPe } = require('./pe-fixture.cjs')
 const STAGING_SCRIPT_FILES = Object.freeze([
   'stage-audio-engine.cjs',
   'audio-engine-toolchain.cjs',
+  'macos-audio-runtime.cjs',
   'generate-audio-capability-manifest.cjs',
   'staged-audio-runtime-observation.cjs',
   'verify-release-capability-consistency.cjs',
@@ -74,6 +75,26 @@ function runtimeFileNames() {
 
 /** Staging parses import tables on Windows, so fixtures must be real PE files. */
 function writeRuntimeFixture(directory, file, options = {}) {
+  if (process.platform === 'darwin') {
+    const marker = JSON.stringify(options.trailer ?? `fixture ${file}`)
+    const source = file.endsWith('.node')
+      ? `const char *twilight_test_node_marker = ${marker}; int twilight_test_node_fixture(void) { return 0; }\n`
+      : `const char *twilight_test_library_marker = ${marker}; int twilight_test_library_fixture(void) { return 0; }\n`
+    const result = spawnSync(
+      'clang',
+      [
+        '-x',
+        'c',
+        '-',
+        file.endsWith('.node') ? '-bundle' : '-dynamiclib',
+        '-o',
+        join(directory, file)
+      ],
+      { input: source, encoding: 'utf8' }
+    )
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    return
+  }
   writeFileSync(join(directory, file), createMinimalPe(options))
 }
 

--- a/scripts/macos-audio-runtime.cjs
+++ b/scripts/macos-audio-runtime.cjs
@@ -1,0 +1,247 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+function commandOutput(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' })
+}
+
+function runCommand(command, args) {
+  execFileSync(command, args, { stdio: 'pipe' })
+}
+
+function parseOtoolDependencies(output) {
+  const lines = String(output).split(/\r?\n/)
+  const dependencies = lines
+    .slice(1)
+    .map((line) => line.trim().match(/^(.*?) \(compatibility version/)?.[1])
+    .filter(Boolean)
+  return lines[0]?.trim().endsWith('.dylib:') ? dependencies.slice(1) : dependencies
+}
+
+function parseOtoolRpaths(output) {
+  const lines = String(output).split(/\r?\n/)
+  const rpaths = []
+  let readingRpath = false
+  for (const line of lines) {
+    if (/^\s*cmd LC_RPATH\s*$/.test(line)) {
+      readingRpath = true
+      continue
+    }
+    if (!readingRpath) continue
+    const value = line.match(/^\s*path (.*?) \(offset \d+\)\s*$/)?.[1]
+    if (value) {
+      rpaths.push(value)
+      readingRpath = false
+    }
+  }
+  return rpaths
+}
+
+function inspectDependencies(filePath, output = commandOutput) {
+  return parseOtoolDependencies(output('otool', ['-L', filePath]))
+}
+
+function inspectRpaths(filePath, output = commandOutput) {
+  return parseOtoolRpaths(output('otool', ['-l', filePath]))
+}
+
+function isSystemDependency(loadPath) {
+  return loadPath.startsWith('/System/Library/') || loadPath.startsWith('/usr/lib/')
+}
+
+function expandLoaderPath(value, sourceFile) {
+  if (value === '@loader_path') return path.dirname(sourceFile)
+  if (value.startsWith('@loader_path/')) {
+    return path.resolve(path.dirname(sourceFile), value.slice('@loader_path/'.length))
+  }
+  return value
+}
+
+function resolveDependencySource(loadPath, sourceFile, rpaths, exists = fs.existsSync) {
+  const candidates = []
+  if (path.isAbsolute(loadPath)) candidates.push(loadPath)
+  else if (loadPath.startsWith('@loader_path/'))
+    candidates.push(expandLoaderPath(loadPath, sourceFile))
+  else if (loadPath.startsWith('@rpath/')) {
+    const suffix = loadPath.slice('@rpath/'.length)
+    for (const rpath of rpaths) {
+      const expanded = expandLoaderPath(rpath, sourceFile)
+      if (path.isAbsolute(expanded)) candidates.push(path.join(expanded, suffix))
+    }
+  }
+  const resolved = candidates.find((candidate) => exists(candidate))
+  if (!resolved) {
+    throw new Error(
+      `Unable to resolve non-system Mach-O dependency ${loadPath} imported by ${sourceFile}`
+    )
+  }
+  return resolved
+}
+
+function validateBundledMacOSRuntime(
+  binaries,
+  {
+    inspectDependencies: dependencies = inspectDependencies,
+    inspectRpaths: rpaths = inspectRpaths,
+    exists = fs.existsSync
+  } = {}
+) {
+  const bundledDependencies = new Set()
+  for (const binary of binaries) {
+    for (const loadPath of dependencies(binary)) {
+      if (isSystemDependency(loadPath)) continue
+      if (!loadPath.startsWith('@loader_path/')) {
+        throw new Error(`Found non-portable Mach-O dependency in ${binary}: ${loadPath}`)
+      }
+      const target = path.resolve(path.dirname(binary), loadPath.slice('@loader_path/'.length))
+      if (!exists(target)) {
+        throw new Error(`Found missing bundled Mach-O dependency in ${binary}: ${loadPath}`)
+      }
+      bundledDependencies.add(target)
+    }
+    for (const rpath of rpaths(binary)) {
+      if (rpath !== '@loader_path' && !rpath.startsWith('@loader_path/')) {
+        throw new Error(`Found non-portable Mach-O rpath in ${binary}: ${rpath}`)
+      }
+    }
+  }
+  return { binaries: binaries.length, bundledDependencies: bundledDependencies.size }
+}
+
+function bundleMacOSRuntimeDependencies(
+  entryFiles,
+  outputDir,
+  {
+    inspectDependencies: dependencies = inspectDependencies,
+    inspectRpaths: rpaths = inspectRpaths,
+    exists = fs.existsSync,
+    realpath = fs.realpathSync,
+    copy = fs.copyFileSync,
+    run = runCommand
+  } = {}
+) {
+  assert.ok(entryFiles.length > 0, 'At least one macOS runtime entry file is required')
+  const entryTargets = new Set(entryFiles.map((filePath) => path.resolve(filePath)))
+  const targetByBasename = new Map()
+  const sourceByTarget = new Map()
+  const queue = []
+  for (const filePath of entryFiles) {
+    const target = path.resolve(filePath)
+    assert.ok(exists(target), `Missing macOS runtime entry file: ${target}`)
+    const basename = path.basename(target)
+    targetByBasename.set(basename, target)
+    sourceByTarget.set(target, target)
+    queue.push(target)
+  }
+
+  const inspected = new Set()
+  const changes = new Map()
+  while (queue.length > 0) {
+    const target = queue.shift()
+    if (inspected.has(target)) continue
+    inspected.add(target)
+    const source = sourceByTarget.get(target) ?? target
+    const sourceRpaths = rpaths(target)
+    for (const loadPath of dependencies(target)) {
+      if (isSystemDependency(loadPath)) continue
+      const basename = path.basename(loadPath)
+      assert.ok(basename && basename !== '.', `Invalid Mach-O dependency in ${target}: ${loadPath}`)
+      let dependencyTarget = targetByBasename.get(basename)
+      if (!dependencyTarget) {
+        const dependencySource = realpath(
+          resolveDependencySource(loadPath, source, sourceRpaths, exists)
+        )
+        dependencyTarget = path.join(outputDir, basename)
+        const existingSource = sourceByTarget.get(dependencyTarget)
+        if (existingSource && realpath(existingSource) !== dependencySource) {
+          throw new Error(`Mach-O dependency basename collision for ${basename}`)
+        }
+        copy(dependencySource, dependencyTarget)
+        targetByBasename.set(basename, dependencyTarget)
+        sourceByTarget.set(dependencyTarget, dependencySource)
+        queue.push(dependencyTarget)
+      } else if (!entryTargets.has(dependencyTarget)) {
+        const dependencySource = realpath(
+          resolveDependencySource(loadPath, source, sourceRpaths, exists)
+        )
+        const existingSource = realpath(sourceByTarget.get(dependencyTarget) ?? dependencyTarget)
+        if (existingSource !== dependencySource) {
+          throw new Error(`Mach-O dependency basename collision for ${basename}`)
+        }
+      }
+      const replacement = `@loader_path/${basename}`
+      if (loadPath !== replacement) {
+        const fileChanges = changes.get(target) ?? []
+        fileChanges.push([loadPath, replacement])
+        changes.set(target, fileChanges)
+      }
+    }
+  }
+
+  const binaries = [...inspected]
+  for (const binary of binaries) {
+    for (const [from, to] of changes.get(binary) ?? []) {
+      run('install_name_tool', ['-change', from, to, binary])
+    }
+    if (binary.endsWith('.dylib')) {
+      run('install_name_tool', ['-id', `@loader_path/${path.basename(binary)}`, binary])
+    }
+    for (const rpath of rpaths(binary)) {
+      if (rpath !== '@loader_path' && !rpath.startsWith('@loader_path/')) {
+        run('install_name_tool', ['-delete_rpath', rpath, binary])
+      }
+    }
+    run('codesign', ['--force', '--sign', '-', '--timestamp=none', binary])
+  }
+
+  const verification = validateBundledMacOSRuntime(binaries)
+  return {
+    files: binaries.sort(),
+    copiedDependencies: binaries.filter((file) => !entryTargets.has(file)).length,
+    verification
+  }
+}
+
+function runtimeBinaries(directory) {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.(?:dylib|node)$/i.test(entry.name))
+    .map((entry) => path.join(directory, entry.name))
+    .sort()
+}
+
+function main(argv) {
+  if (argv.length !== 2 || argv[0] !== '--runtime-dir' || !argv[1]) {
+    throw new Error('Usage: node scripts/macos-audio-runtime.cjs --runtime-dir <directory>')
+  }
+  const directory = path.resolve(argv[1])
+  assert.ok(fs.existsSync(directory), `macOS runtime directory does not exist: ${directory}`)
+  const result = validateBundledMacOSRuntime(runtimeBinaries(directory))
+  console.log(
+    `macOS audio runtime verified: ${result.binaries} Mach-O files, ` +
+      `${result.bundledDependencies} bundled dependency edges`
+  )
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  bundleMacOSRuntimeDependencies,
+  inspectDependencies,
+  inspectRpaths,
+  isSystemDependency,
+  parseOtoolDependencies,
+  parseOtoolRpaths,
+  resolveDependencySource,
+  runtimeBinaries,
+  validateBundledMacOSRuntime
+}

--- a/scripts/macos-audio-runtime.test.cjs
+++ b/scripts/macos-audio-runtime.test.cjs
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  isSystemDependency,
+  parseOtoolDependencies,
+  parseOtoolRpaths,
+  validateBundledMacOSRuntime
+} = require('./macos-audio-runtime.cjs')
+
+test('parses otool dependency and rpath output without treating the Mach-O identity as a load', () => {
+  assert.deepEqual(
+    parseOtoolDependencies(
+      `sample.dylib:\n\t@rpath/sample.dylib (compatibility version 0.0.0, current version 0.0.0)\n\t/opt/homebrew/opt/ffmpeg/lib/libavcodec.63.dylib (compatibility version 63.0.0, current version 63.1.0)\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n`
+    ),
+    ['/opt/homebrew/opt/ffmpeg/lib/libavcodec.63.dylib', '/usr/lib/libSystem.B.dylib']
+  )
+  assert.deepEqual(
+    parseOtoolDependencies(
+      `sample.node:\n\t@loader_path/libtwilight-audio-engine.dylib (compatibility version 0.0.0, current version 0.0.0)\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n`
+    ),
+    ['@loader_path/libtwilight-audio-engine.dylib', '/usr/lib/libSystem.B.dylib']
+  )
+  assert.deepEqual(
+    parseOtoolRpaths(
+      `Load command 1\n          cmd LC_RPATH\n      cmdsize 48\n         path @loader_path (offset 12)\nLoad command 2\n          cmd LC_RPATH\n      cmdsize 88\n         path /private/tmp/audio-engine/build/default (offset 12)\n`
+    ),
+    ['@loader_path', '/private/tmp/audio-engine/build/default']
+  )
+})
+
+test('recognizes only Apple platform locations as system dependencies', () => {
+  assert.equal(isSystemDependency('/System/Library/Frameworks/CoreAudio.framework/CoreAudio'), true)
+  assert.equal(isSystemDependency('/usr/lib/libSystem.B.dylib'), true)
+  assert.equal(isSystemDependency('/opt/homebrew/opt/ffmpeg/lib/libavcodec.63.dylib'), false)
+  assert.equal(isSystemDependency('@loader_path/libavcodec.63.dylib'), false)
+})
+
+test('packaged macOS runtime rejects absolute third-party loads and missing loader-path siblings', () => {
+  const runtimeDir = path.resolve('/tmp/twilight-macos-runtime-fixture')
+  const engine = path.join(runtimeDir, 'libtwilight-audio-engine.dylib')
+  const node = path.join(runtimeDir, 'twilight_audio_node.node')
+  assert.throws(
+    () =>
+      validateBundledMacOSRuntime([engine, node], {
+        inspectDependencies: (file) =>
+          file === engine
+            ? ['/opt/homebrew/opt/ffmpeg/lib/libavcodec.63.dylib']
+            : ['@loader_path/libtwilight-audio-engine.dylib'],
+        inspectRpaths: () => [],
+        exists: () => true
+      }),
+    /non-portable Mach-O dependency/
+  )
+  assert.throws(
+    () =>
+      validateBundledMacOSRuntime([engine, node], {
+        inspectDependencies: () => ['@loader_path/libmissing.dylib'],
+        inspectRpaths: () => [],
+        exists: () => false
+      }),
+    /missing bundled Mach-O dependency/
+  )
+})
+
+test('packaged macOS runtime accepts loader-relative dependencies with no build-machine rpaths', () => {
+  const runtimeDir = path.resolve('/tmp/twilight-macos-runtime-fixture')
+  const engine = path.join(runtimeDir, 'libtwilight-audio-engine.dylib')
+  const node = path.join(runtimeDir, 'twilight_audio_node.node')
+  const dependency = path.join(runtimeDir, 'libavcodec.63.dylib')
+  const result = validateBundledMacOSRuntime([engine, node, dependency], {
+    inspectDependencies: (file) =>
+      file === node
+        ? ['@loader_path/libtwilight-audio-engine.dylib', '/usr/lib/libSystem.B.dylib']
+        : file === engine
+          ? ['@loader_path/libavcodec.63.dylib']
+          : ['/usr/lib/libSystem.B.dylib'],
+    inspectRpaths: () => ['@loader_path'],
+    exists: () => true
+  })
+  assert.deepEqual(result, { binaries: 3, bundledDependencies: 2 })
+})
+
+test('Node-API uses the native loader-relative rpath on macOS', () => {
+  const cmake = fs.readFileSync(
+    path.join(__dirname, '..', 'audio-engine', 'CMakeLists.txt'),
+    'utf8'
+  )
+  assert.match(cmake, /if\(APPLE\)\s+set\(TAE_NAPI_RPATH "@loader_path"\)/)
+  assert.match(cmake, /BUILD_RPATH "\$\{TAE_NAPI_RPATH\}"/)
+  assert.match(cmake, /INSTALL_RPATH "\$\{TAE_NAPI_RPATH\}"/)
+})

--- a/scripts/release-delivery-policy.test.cjs
+++ b/scripts/release-delivery-policy.test.cjs
@@ -21,6 +21,16 @@ test('release configuration is intentionally unsigned and does not advertise a p
   assert.equal(fs.existsSync(path.join(root, 'electron-builder.release-win.yml')), false)
 })
 
+test('macOS hardened runtime permits bundled native code under local signatures', () => {
+  const builder = read('electron-builder.yml')
+  const entitlements = read('build/entitlements.mac.plist')
+  assert.match(builder, /^mac:\s*\n\s+entitlementsInherit: build\/entitlements\.mac\.plist$/m)
+  assert.match(
+    entitlements,
+    /<key>com\.apple\.security\.cs\.disable-library-validation<\/key>\s*<true\/>/
+  )
+})
+
 test('Windows packaging strips copied native binaries while unsigned releases stay fail-closed', () => {
   const afterPack = read('scripts/after-pack-windows.cjs')
   const packageBuild = read('scripts/build-app-package.cjs')

--- a/scripts/stage-audio-engine.cjs
+++ b/scripts/stage-audio-engine.cjs
@@ -1,9 +1,18 @@
-const { copyFileSync, existsSync, mkdirSync, readFileSync, statSync } = require('node:fs')
+const {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync
+} = require('node:fs')
 const { dirname, join, resolve } = require('node:path')
 const { collectImportClosure } = require('./pe-imports.cjs')
 const { createAudioCapabilityManifest } = require('./generate-audio-capability-manifest.cjs')
 const { createReleaseCapabilityStatus } = require('./verify-release-capability-consistency.cjs')
 const { readStagedAudioRuntimeObservation } = require('./staged-audio-runtime-observation.cjs')
+const { bundleMacOSRuntimeDependencies } = require('./macos-audio-runtime.cjs')
 
 const root = join(__dirname, '..')
 const outputDir = join(root, 'resources', 'audio-engine')
@@ -70,6 +79,12 @@ if (!buildDir) {
 
 mkdirSync(outputDir, { recursive: true })
 
+if (process.platform === 'darwin') {
+  for (const name of readdirSync(outputDir)) {
+    if (name.endsWith('.dylib')) rmSync(join(outputDir, name), { force: true })
+  }
+}
+
 function stageFile(source, file) {
   const target = join(outputDir, file)
   try {
@@ -88,6 +103,17 @@ function stageFile(source, file) {
 
 for (const file of runtimeFiles) {
   stageFile(join(buildDir, file), file)
+}
+
+if (process.platform === 'darwin') {
+  const bundled = bundleMacOSRuntimeDependencies(
+    runtimeFiles.map((file) => join(outputDir, file)),
+    outputDir
+  )
+  console.log(
+    `已暂存 macOS 音频动态依赖：${bundled.copiedDependencies} 个；` +
+      `已验证 ${bundled.verification.binaries} 个 Mach-O 文件`
+  )
 }
 
 /**

--- a/scripts/verify-release-capability-consistency.cjs
+++ b/scripts/verify-release-capability-consistency.cjs
@@ -77,6 +77,23 @@ function allImportsInspectable(manifest) {
   return manifest.nativeArtifacts.every((artifact) => artifact.importInspection?.status === 'ok')
 }
 
+function listCapabilityNativeBinaries(nativeDir) {
+  if (fs.existsSync(path.join(nativeDir, 'twilight-audio-engine.dll'))) {
+    return listNativeBinaries(nativeDir)
+  }
+  const engines = ['libtwilight-audio-engine.dylib', 'libtwilight-audio-engine.so'].filter((name) =>
+    fs.existsSync(path.join(nativeDir, name))
+  )
+  assert.equal(
+    engines.length,
+    1,
+    `Expected exactly one macOS/Linux native audio engine in ${nativeDir}`
+  )
+  const addon = path.join(nativeDir, 'twilight_audio_node.node')
+  assert.ok(fs.existsSync(addon), `Missing required native binary: ${addon}`)
+  return [path.join(nativeDir, engines[0]), addon]
+}
+
 function observationCapability(observation, name, key) {
   const value = observation?.capabilities?.[name]
   return value && typeof value === 'object' && typeof value[key] === 'boolean' ? value[key] : null
@@ -123,7 +140,7 @@ function capabilityStatus(status, buildStatus, runtimeStatus, deviceVerification
 }
 
 function createReleaseCapabilityStatus({ nativeDir, manifest }) {
-  listNativeBinaries(nativeDir)
+  listCapabilityNativeBinaries(nativeDir)
   const importsInspectable = allImportsInspectable(manifest)
   const vst3HelpersPresent = assertVst3HelperPair(nativeDir)
   const observation = assertPermittedRuntimeObservation(manifest)
@@ -395,8 +412,10 @@ function verifyReleaseCapabilityConsistency(options) {
   assert.ok(fs.existsSync(nativeDir), `Staged native directory does not exist: ${nativeDir}`)
   assert.ok(fs.existsSync(manifestPath), `Missing audio capability manifest: ${manifestPath}`)
   const manifest = assertManifestMatchesArtifacts(nativeDir, manifestPath)
-  const nativeBinaries = listNativeBinaries(nativeDir)
-  const runtimeDependencies = listRuntimeDependencies(nativeDir, nativeBinaries)
+  const nativeBinaries = listCapabilityNativeBinaries(nativeDir)
+  const runtimeDependencies = nativeBinaries.some((file) => file.endsWith('.dll'))
+    ? listRuntimeDependencies(nativeDir, nativeBinaries)
+    : []
   const status = createReleaseCapabilityStatus({ nativeDir, manifest })
   const productRoot = path.resolve(options.productRoot || path.join(__dirname, '..'))
   assertControlledProductClaims(productRoot)
@@ -463,5 +482,6 @@ module.exports = {
   declarationFields,
   parseArgs,
   parseDeclaration,
+  listCapabilityNativeBinaries,
   verifyReleaseCapabilityConsistency
 }

--- a/scripts/verify-release-capability-consistency.test.cjs
+++ b/scripts/verify-release-capability-consistency.test.cjs
@@ -103,6 +103,20 @@ test('controlled capability statuses retain staged-build and real-device dimensi
   }
 })
 
+test('macOS core artifacts can produce capability status without Windows-only binaries', () => {
+  const directory = fixtureDirectory()
+  try {
+    fs.writeFileSync(path.join(directory, 'libtwilight-audio-engine.dylib'), 'mac engine')
+    fs.writeFileSync(path.join(directory, 'twilight_audio_node.node'), 'mac node addon')
+    const manifest = createAudioCapabilityManifest({ artifactDir: directory })
+    const status = createReleaseCapabilityStatus({ nativeDir: directory, manifest })
+    assert.equal(status.capabilities.ASIO.status, 'unverified')
+    assert.equal(status.capabilities.VST3.status, 'not-built')
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
 test('ASIO-disabled runtime evidence reports not-built instead of inferring support from the core DLL', () => {
   const directory = fixtureDirectory()
   try {


### PR DESCRIPTION
## Summary

- make native audio capability staging work on macOS without requiring Windows DLL or ASIO helper artifacts
- recursively bundle non-system Mach-O dependencies, rewrite load paths to `@loader_path`, and fail closed on missing or build-machine paths
- use the macOS loader-relative RPATH for the Node-API addon and verify the packaged runtime closure in CI
- allow locally signed Hardened Runtime processes to load the bundled Electron and native audio code

## Verification

- `pnpm run lint`
- `pnpm run test:app` — 339 passed
- `pnpm run test:release-artifacts` — 51 passed
- `pnpm run build:mac`
- verified the signed app with `codesign --verify --deep --strict`
- verified 17 arm64 Mach-O runtime files and loaded the packaged Node-API addon with 42 exports
- mounted the generated DMG and launched the app for 12 seconds without signing or dynamic-library load errors

## Release boundary

The generated local package uses the available local signing identity. Notarization remains disabled by the existing project configuration, so this change does not claim a notarized public macOS release.
