### PR TITLE
Fix NCM API port collisions

### DIFF
--- a/src/main/ncm/api.test.ts
+++ b/src/main/ncm/api.test.ts
@@ -1,6 +1,55 @@
 import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
+import { waitForListeningPort } from './serverBinding.ts'
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+test('NCM API binding reports its actual isolated port instead of a foreign listener', async () => {
+  const foreignServer = createServer((_request, response) => response.end('foreign-service'))
+  const ncmServer = createServer((_request, response) => {
+    response.setHeader('content-type', 'application/json')
+    response.end('{"service":"ncm"}')
+  })
+
+  try {
+    foreignServer.listen(0, '127.0.0.1')
+    const foreignPort = await waitForListeningPort(foreignServer)
+
+    ncmServer.listen(0, '127.0.0.1')
+    const ncmPort = await waitForListeningPort(ncmServer)
+
+    assert.notEqual(ncmPort, foreignPort)
+    const response = await fetch(`http://127.0.0.1:${ncmPort}/login/qr/key`)
+    assert.deepEqual(await response.json(), { service: 'ncm' })
+  } finally {
+    await Promise.all([closeServer(ncmServer), closeServer(foreignServer)])
+  }
+})
+
+test('NCM API binding rejects when the server cannot listen', async () => {
+  const foreignServer = createServer()
+  const collidingServer = createServer()
+
+  try {
+    foreignServer.listen(0, '127.0.0.1')
+    const foreignPort = await waitForListeningPort(foreignServer)
+    collidingServer.listen(foreignPort, '127.0.0.1')
+
+    await assert.rejects(waitForListeningPort(collidingServer), (error: NodeJS.ErrnoException) => {
+      assert.equal(error.code, 'EADDRINUSE')
+      return true
+    })
+  } finally {
+    await closeServer(foreignServer)
+  }
+})
 
 test('NCM API server starts once on the first request and gates fetch on readiness', async () => {
   const source = await readFile(new URL('./api.ts', import.meta.url), 'utf8')
@@ -9,9 +58,14 @@ test('NCM API server starts once on the first request and gates fetch on readine
   assert.match(source, /if \(runtime\.ncmServerPromise\) return runtime\.ncmServerPromise/)
   assert.match(source, /const startup = startNcmServer\(\)/)
   assert.match(source, /await ensureNcmServer\(\)/)
+  assert.match(source, /port: NCM_API_EPHEMERAL_PORT/)
+  assert.match(source, /await waitForListeningPort\(ncmApp\.server\)/)
+  assert.match(source, /getListeningPort\(runtime\.ncmServer\)/)
   assert.match(source, /const res = await fetch\(url, \{/)
+  assert.match(source, /const responseText = await res\.text\(\)/)
   assert.match(source, /signal: controller\.signal,/)
   assert.match(source, /headers,/)
   assert.match(source, /dispatcher: NCM_KEEP_ALIVE_AGENT/)
+  assert.doesNotMatch(source, /NCM_API_PORT = 3100/)
   assert.doesNotMatch(source, /export async function setupNcmApi/)
 })

--- a/src/main/ncm/api.ts
+++ b/src/main/ncm/api.ts
@@ -13,12 +13,16 @@ import {
 } from '../security/ipcValidation.ts'
 import { assertTrustedIpcSender } from '../security/electronSecurity.ts'
 import { setupNcmCloudTransferIpc } from './cloudTransfer.ts'
+import { getListeningPort, waitForListeningPort } from './serverBinding.ts'
 import { Agent } from 'undici'
 
-export const NCM_API_PORT = 3100
 export const NCM_API_HOST = '127.0.0.1'
 export const NCM_OFFICIAL_LOGIN_TIMEOUT_MS = 180000
 export const NCM_API_REQUEST_TIMEOUT_MS = 25000
+// The upstream server treats numeric 0 as absent (`options.port || 3000`). A string keeps the
+// request for an OS-assigned port while still being converted to number 0 inside serveNcmApi.
+const NCM_API_EPHEMERAL_PORT = '0' as unknown as number
+const NCM_API_ORIGIN = `http://${NCM_API_HOST}`
 const NCM_KEEP_ALIVE_AGENT = new Agent({
   connections: 8,
   keepAliveTimeout: 60_000,
@@ -73,8 +77,11 @@ export async function requestNcmApi(
   if (!normalizedPath) {
     return { code: -1, message: 'Invalid NetEase API path' }
   }
+  let port: number
   try {
     await ensureNcmServer()
+    if (!runtime.ncmServer) throw new Error('NetEase API server did not start')
+    port = getListeningPort(runtime.ncmServer)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.error('网易云音乐服务启动失败：', redactSensitiveText(message))
@@ -84,7 +91,7 @@ export async function requestNcmApi(
   const timestamp = shouldTimestampNcmApiPath(normalizedPath)
     ? `${separator}timestamp=${Date.now()}`
     : ''
-  const url = `http://${NCM_API_HOST}:${NCM_API_PORT}${normalizedPath}${timestamp}`
+  const url = `http://${NCM_API_HOST}:${port}${normalizedPath}${timestamp}`
   const headers: Record<string, string> = {}
   const normalizedCookie = normalizeNcmCookie(cookie)
   if (normalizedCookie) {
@@ -109,7 +116,13 @@ export async function requestNcmApi(
       headers,
       dispatcher: NCM_KEEP_ALIVE_AGENT
     } as RequestInit)
-    return await res.json()
+    const responseText = await res.text()
+    try {
+      return JSON.parse(responseText) as unknown
+    } catch {
+      const contentType = res.headers.get('content-type') || 'unknown content type'
+      throw new Error(`NetEase API returned invalid JSON (HTTP ${res.status}, ${contentType})`)
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.error(
@@ -223,9 +236,11 @@ export async function openNcmOfficialLogin(): Promise<string> {
 
 export function setupNcmIpc(): void {
   setupNcmCloudTransferIpc()
-  ipcMain.handle('ncm:getPort', (event) => {
+  ipcMain.handle('ncm:getPort', async (event) => {
     assertTrustedIpcSender(event, 'NCM IPC')
-    return NCM_API_PORT
+    await ensureNcmServer()
+    if (!runtime.ncmServer) throw new Error('NetEase API server did not start')
+    return getListeningPort(runtime.ncmServer)
   })
 
   ipcMain.handle('ncm:getCachedSong', async (_event, songId: number) => {
@@ -261,8 +276,8 @@ function normalizeNcmApiPath(path: unknown): string | null {
   if (!normalized.startsWith('/') || normalized.startsWith('//') || normalized.includes('\\'))
     return null
   try {
-    const parsed = new URL(`http://${NCM_API_HOST}:${NCM_API_PORT}${normalized}`)
-    if (parsed.origin !== `http://${NCM_API_HOST}:${NCM_API_PORT}`) return null
+    const parsed = new URL(normalized, NCM_API_ORIGIN)
+    if (parsed.origin !== NCM_API_ORIGIN) return null
     return normalized
   } catch {
     return null
@@ -311,10 +326,12 @@ async function startNcmServer(): Promise<void> {
   }
   const { serveNcmApi } = await import('@neteasecloudmusicapienhanced/api/server.js')
   const ncmApp = await serveNcmApi({
-    port: NCM_API_PORT,
+    port: NCM_API_EPHEMERAL_PORT,
     host: NCM_API_HOST,
     checkVersion: false
   })
+  if (!ncmApp.server) throw new Error('NetEase API server did not return a listener')
+  const port = await waitForListeningPort(ncmApp.server)
   if (runtime.forceQuit) {
     ncmApp.server.close()
     throw new Error('NetEase API server startup was cancelled')
@@ -323,5 +340,5 @@ async function startNcmServer(): Promise<void> {
   ncmApp.server.once('close', () => {
     if (runtime.ncmServer === ncmApp.server) runtime.ncmServer = null
   })
-  console.log(`网易云音乐服务已启动：http://${NCM_API_HOST}:${NCM_API_PORT}`)
+  console.log(`网易云音乐服务已启动：http://${NCM_API_HOST}:${port}`)
 }

--- a/src/main/ncm/serverBinding.ts
+++ b/src/main/ncm/serverBinding.ts
@@ -1,0 +1,33 @@
+import type { Server } from 'node:http'
+
+export function getListeningPort(server: Server): number {
+  const address = server.address()
+  if (!server.listening || !address || typeof address === 'string') {
+    throw new Error('NetEase API server is not listening on a TCP port')
+  }
+  return address.port
+}
+
+export async function waitForListeningPort(server: Server): Promise<number> {
+  if (server.listening) return getListeningPort(server)
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      server.removeListener('listening', handleListening)
+      server.removeListener('error', handleError)
+    }
+    const handleListening = (): void => {
+      cleanup()
+      resolve()
+    }
+    const handleError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+
+    server.once('listening', handleListening)
+    server.once('error', handleError)
+  })
+
+  return getListeningPort(server)
+}


### PR DESCRIPTION
## Summary

- bind the embedded NetEase API server to an OS-assigned loopback port instead of fixed port 3100
- wait for the listener to become ready, propagate bind failures, and route requests through the actual bound port
- report invalid upstream JSON with HTTP status and content type
- add regression coverage for isolated port binding and listen failures

## Testing

- `pnpm run build`
- `pnpm exec eslint src/main/ncm/api.ts src/main/ncm/api.test.ts src/main/ncm/serverBinding.ts`
- `pnpm exec prettier --check src/main/ncm/api.ts src/main/ncm/api.test.ts src/main/ncm/serverBinding.ts`
- `node --experimental-strip-types --test src/main/ncm/api.test.ts resources/plugins/ncm-provider/index.test.mjs` (64 passed)
- packaged and installed macOS app smoke test while Loki retained port 3100; NCM bound to an ephemeral port and the streaming page loaded without the JSON parse error

## Known unrelated test failures

- `pnpm run test:plugins` has 2 existing macOS temporary-path assertion failures caused by `/var/...` resolving to `/private/var/...` in `packageSecurity.test.ts` and `pathGrants.test.ts`; 382 tests passed and 1 was skipped.